### PR TITLE
Make the command interface fancy

### DIFF
--- a/cfmtoolbox/plugins/random_sampling.py
+++ b/cfmtoolbox/plugins/random_sampling.py
@@ -6,12 +6,15 @@ from cfmtoolbox.models import CFM, Cardinality, Feature, FeatureNode
 
 
 @app.command()
-def random_sampling(amount: int = 1) -> list[FeatureNode] | None:
-    if app.model is None:
+def random_sampling(model: CFM | None, amount: int = 1) -> CFM | None:
+    if model is None:
         print("No model loaded.")
         return None
 
-    return [RandomSampler(app.model).random_sampling() for _ in range(amount)]
+    for _ in range(amount):
+        RandomSampler(model).random_sampling()
+
+    return model
 
 
 class RandomSampler:


### PR DESCRIPTION
This PR changes the signature of commands to deprecate access to the global `app.model` instance. Commands are now required to have a CFM argument like this: `def my_command(model: CFM | None, extra_args: int) -> CFM | None`. Every `None` in this signature is still up for debate.