### PR TITLE
Fix json impex could not handle circular refs

### DIFF
--- a/cfmtoolbox/plugins/json_export.py
+++ b/cfmtoolbox/plugins/json_export.py
@@ -1,9 +1,55 @@
 import json
-from dataclasses import asdict
 
-from cfmtoolbox import CFM, app
+from cfmtoolbox import CFM, Cardinality, Constraint, Feature, Interval, app
 
 
 @app.exporter(".json")
 def export_json(cfm: CFM) -> bytes:
-    return json.dumps(asdict(cfm), indent=2).encode()
+    root_feature = cfm.features[0]
+
+    serialized_root = serialize_feature(root_feature)
+    serialized_constraints = list(
+        map(serialize_constraint, [*cfm.require_constraints, *cfm.exclude_constraints])
+    )
+
+    serialized_cfm = {
+        "root": serialized_root,
+        "constraints": serialized_constraints,
+    }
+
+    return json.dumps(serialized_cfm, indent=2).encode()
+
+
+def serialize_feature(feature: Feature) -> dict:
+    return {
+        "name": feature.name,
+        "instance_cardinality": serialize_cardinality(feature.instance_cardinality),
+        "group_type_cardinality": serialize_cardinality(feature.group_type_cardinality),
+        "group_instance_cardinality": serialize_cardinality(
+            feature.group_instance_cardinality
+        ),
+        "children": list(map(serialize_feature, feature.children)),
+    }
+
+
+def serialize_cardinality(cardinality: Cardinality) -> dict:
+    return {
+        "intervals": list(map(serialize_interval, cardinality.intervals)),
+    }
+
+
+def serialize_interval(interval: Interval) -> dict:
+    return {
+        "lower": interval.lower,
+        "upper": interval.upper,
+    }
+
+
+def serialize_constraint(constraint: Constraint) -> dict:
+    return {
+        "require": constraint.require,
+        "first_feature_name": constraint.first_feature.name,
+        "first_cardinality": serialize_cardinality(constraint.first_cardinality),
+        "second_feature_name": constraint.second_feature.name,
+        "second_cardinality": serialize_cardinality(constraint.second_cardinality),
+    }

--- a/cfmtoolbox/plugins/json_import.py
+++ b/cfmtoolbox/plugins/json_import.py
@@ -6,36 +6,156 @@ from cfmtoolbox import CFM, Cardinality, Constraint, Feature, Interval, app
 JSON: TypeAlias = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
 
 
-def parse_interval(data: JSON) -> Interval:
-    if not isinstance(data, dict):
-        raise TypeError(f"Interval must be an object: {data}")
+@app.importer(".json")
+def import_json(raw_data: bytes) -> CFM:
+    return parse_cfm(json.loads(raw_data))
 
-    if not isinstance(data["lower"], int) or isinstance(data["lower"], bool):
-        raise TypeError("Interval lower must be an integer")
 
-    if not isinstance(data["upper"], (type(None), int)) or isinstance(
-        data["upper"], bool
-    ):
-        raise TypeError("Interval lower must be null or an integer")
+def parse_cfm(serialized_cfm: JSON) -> CFM:
+    if not isinstance(serialized_cfm, dict):
+        raise TypeError(f"CFM must be an object: {serialized_cfm}")
 
-    return Interval(
-        lower=data["lower"],
-        upper=data["upper"],
+    if not isinstance(serialized_cfm["constraints"], list):
+        raise TypeError(
+            f"CFM constraints must be a list: {serialized_cfm['constraints']}"
+        )
+
+    features = parse_root(serialized_cfm["root"])
+
+    constraints = [
+        parse_constraint(serialized_constraint, features)
+        for serialized_constraint in serialized_cfm["constraints"]
+    ]
+
+    require_constraints = list(filter(lambda c: c.require, constraints))
+    exclude_constraints = list(filter(lambda c: not c.require, constraints))
+
+    return CFM(
+        features=features,
+        require_constraints=require_constraints,
+        exclude_constraints=exclude_constraints,
     )
 
 
-def parse_constraint(data: JSON) -> Constraint:
-    if not isinstance(data, dict):
-        raise TypeError(f"Constraint must be an object: {data}")
+def parse_root(serialized_root: JSON) -> list[Feature]:
+    root = parse_feature(serialized_root, parents=[])
 
-    if not isinstance(data["require"], bool):
-        raise TypeError(f"Constraint require must be a boolean: {data['require']}")
+    features = [root]
 
-    require = data["require"]
-    first_feature = parse_feature(data["first_feature"])
-    first_cardinality = parse_cardinality(data["first_cardinality"])
-    second_feature = parse_feature(data["second_feature"])
-    second_cardinality = parse_cardinality(data["second_cardinality"])
+    for feature in features:
+        features.extend(feature.children)
+
+    return features
+
+
+def parse_feature(serialized_feature: JSON, /, parents: list[Feature]) -> Feature:
+    if not isinstance(serialized_feature, dict):
+        raise TypeError(f"Feature must be an object: {serialized_feature}")
+
+    if not isinstance(serialized_feature["name"], str):
+        raise TypeError(f"Feature name must be a string: {serialized_feature['name']}")
+
+    if not isinstance(serialized_feature["children"], list):
+        raise TypeError(
+            f"Feature children must be a list: {serialized_feature['children']}"
+        )
+
+    name = serialized_feature["name"]
+
+    instance_cardinality = parse_cardinality(serialized_feature["instance_cardinality"])
+
+    group_type_cardinality = parse_cardinality(
+        serialized_feature["group_type_cardinality"]
+    )
+
+    group_instance_cardinality = parse_cardinality(
+        serialized_feature["group_instance_cardinality"]
+    )
+
+    feature = Feature(
+        name=name,
+        instance_cardinality=instance_cardinality,
+        group_type_cardinality=group_type_cardinality,
+        group_instance_cardinality=group_instance_cardinality,
+        parents=parents,
+        children=[],
+    )
+
+    feature.children = [
+        parse_feature(serialized_child, parents=[feature])
+        for serialized_child in serialized_feature["children"]
+    ]
+
+    return feature
+
+
+def parse_cardinality(serialized_cardinality: JSON) -> Cardinality:
+    if not isinstance(serialized_cardinality, dict):
+        raise TypeError(f"Cardinality must be an object: {serialized_cardinality}")
+
+    if not isinstance(serialized_cardinality["intervals"], list):
+        raise TypeError(
+            f"Cardinality intervals must be a list: {serialized_cardinality['intervals']}"
+        )
+
+    intervals = list(map(parse_interval, serialized_cardinality["intervals"]))
+    return Cardinality(intervals=intervals)
+
+
+def parse_interval(serialized_interval: JSON) -> Interval:
+    if not isinstance(serialized_interval, dict):
+        raise TypeError(f"Interval must be an object: {serialized_interval}")
+
+    if not isinstance(serialized_interval["lower"], int) or isinstance(
+        serialized_interval["lower"], bool
+    ):
+        raise TypeError("Interval lower must be an integer")
+
+    if not isinstance(serialized_interval["upper"], (int, type(None))) or isinstance(
+        serialized_interval["upper"], bool
+    ):
+        raise TypeError("Interval upper must be an integer or null")
+
+    return Interval(
+        lower=serialized_interval["lower"],
+        upper=serialized_interval["upper"],
+    )
+
+
+def parse_constraint(
+    serialized_constraint: JSON, /, features: list[Feature]
+) -> Constraint:
+    if not isinstance(serialized_constraint, dict):
+        raise TypeError(f"Constraint must be an object: {serialized_constraint}")
+
+    if not isinstance(serialized_constraint["require"], bool):
+        raise TypeError(
+            f"Constraint require must be a boolean: {serialized_constraint['require']}"
+        )
+
+    if not isinstance(serialized_constraint["first_feature_name"], str):
+        raise TypeError(
+            f"Constraint first feature name must be a str: {serialized_constraint['first_feature_name']}"
+        )
+
+    if not isinstance(serialized_constraint["second_feature_name"], str):
+        raise TypeError(
+            f"Constraint second feature name must be a str: {serialized_constraint['second_feature_name']}"
+        )
+
+    require = serialized_constraint["require"]
+
+    first_feature = require_feature(
+        serialized_constraint["first_feature_name"], features
+    )
+
+    first_cardinality = parse_cardinality(serialized_constraint["first_cardinality"])
+
+    second_feature = require_feature(
+        serialized_constraint["second_feature_name"], features
+    )
+
+    second_cardinality = parse_cardinality(serialized_constraint["second_cardinality"])
 
     return Constraint(
         require=require,
@@ -46,75 +166,8 @@ def parse_constraint(data: JSON) -> Constraint:
     )
 
 
-def parse_cardinality(data: JSON) -> Cardinality:
-    if not isinstance(data, dict):
-        raise TypeError(f"Cardinality must be an object: {data}")
-
-    if not isinstance(data["intervals"], list):
-        raise TypeError(f"Cardinality intervals must be a list: {data['intervals']}")
-
-    intervals = list(map(parse_interval, data["intervals"]))
-    return Cardinality(intervals=intervals)
-
-
-def parse_feature(data: JSON) -> Feature:
-    if not isinstance(data, dict):
-        raise TypeError(f"Feature must be an object: {data}")
-
-    if not isinstance(data["name"], str):
-        raise TypeError(f"Feature name must be a string: {data['name']}")
-
-    if not isinstance(data["parents"], list):
-        raise TypeError(f"Feature parents must be a list: {data['parents']}")
-
-    if not isinstance(data["children"], list):
-        raise TypeError(f"Feature children must be a list: {data['children']}")
-
-    name = data["name"]
-    instance_cardinality = parse_cardinality(data["instance_cardinality"])
-    group_type_cardinality = parse_cardinality(data["group_type_cardinality"])
-    group_instance_cardinality = parse_cardinality(data["group_instance_cardinality"])
-    parents = list(map(parse_feature, data["parents"]))
-    children = list(map(parse_feature, data["children"]))
-
-    return Feature(
-        name=name,
-        instance_cardinality=instance_cardinality,
-        group_type_cardinality=group_type_cardinality,
-        group_instance_cardinality=group_instance_cardinality,
-        parents=parents,
-        children=children,
-    )
-
-
-def parse_cfm(data: JSON) -> CFM:
-    if not isinstance(data, dict):
-        raise TypeError(f"CFM must be an object: {data}")
-
-    if not isinstance(data["features"], list):
-        raise TypeError(f"CFM feature must be a list: {data['features']}")
-
-    if not isinstance(data["require_constraints"], list):
-        raise TypeError(
-            f"CFM require constraints must be a list: {data['require_constraints']}"
-        )
-
-    if not isinstance(data["exclude_constraints"], list):
-        raise TypeError(
-            f"CFM exclude constraints must be a list: {data['exclude_constraints']}"
-        )
-
-    features = list(map(parse_feature, data["features"]))
-    require_constraints = list(map(parse_constraint, data["require_constraints"]))
-    exclude_constraints = list(map(parse_constraint, data["exclude_constraints"]))
-
-    return CFM(
-        features=features,
-        require_constraints=require_constraints,
-        exclude_constraints=exclude_constraints,
-    )
-
-
-@app.importer(".json")
-def import_json(raw_data: bytes) -> CFM:
-    return parse_cfm(json.loads(raw_data))
+def require_feature(feature_name: str, features: list[Feature]) -> Feature:
+    try:
+        return next(feature for feature in features if feature.name == feature_name)
+    except StopIteration:
+        raise ValueError(f"Feature {feature_name} not found")

--- a/tests/data/sandwich.json
+++ b/tests/data/sandwich.json
@@ -1,166 +1,140 @@
 {
-  "features": [
-    {
-      "name": "sandwich",
-      "instance_cardinality": { "intervals": [{"lower": 1, "upper": 1}] },
-      "group_type_cardinality": { "intervals": [{"lower": 1, "upper": 3}] },
-      "group_instance_cardinality": { "intervals": [{"lower": 2, "upper": 7}] },
-      "parents": [],
-      "children": [
-        { 
-          "name": "bread", 
-          "instance_cardinality": { "intervals": [{"lower": 2, "upper": 2}] },
-          "group_type_cardinality": { "intervals": [{"lower": 1, "upper": 1}] },
-          "group_instance_cardinality": { "intervals": [{"lower": 1, "upper": 1}] },
-          "parents": [], 
-          "children": [
-            { 
-              "name": "sourdough", 
-              "instance_cardinality": { "intervals": [{"lower": 0, "upper": 1}] },
-              "group_type_cardinality": { "intervals": [] },
-              "group_instance_cardinality": { "intervals": [] },
-              "parents": [], 
-              "children": [] 
-            }, 
-            { 
-              "name": "wheat",  
-              "instance_cardinality": { "intervals": [{"lower": 0, "upper": 1}] },
-              "group_type_cardinality": { "intervals": [] },
-              "group_instance_cardinality": { "intervals": [] },
-              "parents": [], 
-              "children": [] 
-            }
-          ] 
-        }, 
-        { 
-          "name": "cheese-mix",  
-          "instance_cardinality": { "intervals": [{"lower": 0, "upper": 0}, {"lower": 2, "upper": 4}] },
-          "group_type_cardinality": { "intervals": [{"lower" : 1, "upper": 3}] },
-          "group_instance_cardinality": { "intervals": [{"lower" : 3, "upper": 3}] },
-          "parents": [], 
-          "children": [
-            { 
-              "name": "cheddar", 
-              "instance_cardinality": { "intervals": [{"lower": 0, "upper": 1}] },
-              "group_type_cardinality": { "intervals": [] },
-              "group_instance_cardinality": { "intervals": [] },
-              "parents": [], 
-              "children": [] 
-            }, 
-            { 
-              "name": "swiss", 
-              "instance_cardinality": { "intervals": [{"lower": 0, "upper": 2}] },
-              "group_type_cardinality": { "intervals": [] },
-              "group_instance_cardinality": { "intervals": [] },
-              "parents": [], 
-              "children": [] 
-            },
-            { 
-              "name": "gouda", 
-              "instance_cardinality": { "intervals": [{"lower": 0, "upper": 3}] },
-              "group_type_cardinality": { "intervals": [] },
-              "group_instance_cardinality": { "intervals": [] },
-              "parents": [], 
-              "children": [] 
-            }
-          ] 
+  "root": {
+    "name": "sandwich",
+    "instance_cardinality": { "intervals": [{ "lower": 1, "upper": 1 }] },
+    "group_type_cardinality": { "intervals": [{ "lower": 1, "upper": 3 }] },
+    "group_instance_cardinality": { "intervals": [{ "lower": 2, "upper": 7 }] },
+    "children": [
+      {
+        "name": "bread",
+        "instance_cardinality": { "intervals": [{ "lower": 2, "upper": 2 }] },
+        "group_type_cardinality": { "intervals": [{ "lower": 1, "upper": 1 }] },
+        "group_instance_cardinality": {
+          "intervals": [{ "lower": 1, "upper": 1 }]
         },
-        { 
-          "name": "veggies",  
-          "instance_cardinality": { "intervals": [{"lower": 0, "upper": 1}] },
-          "group_type_cardinality": { "intervals": [{"lower" : 1, "upper": 3}] },
-          "group_instance_cardinality": { "intervals": [{"lower" : 1, "upper": null}] },
-          "parents": [], 
-          "children": [
-            { 
-              "name": "lettuce", 
-              "instance_cardinality": { "intervals": [{"lower": 0, "upper": null}] },
-              "group_type_cardinality": { "intervals": [] },
-              "group_instance_cardinality": { "intervals": [] },
-              "parents": [], 
-              "children": [] 
-            }, 
-            { 
-              "name": "tomato", 
-              "instance_cardinality": { "intervals": [{"lower": 0, "upper": null}] },
-              "group_type_cardinality": { "intervals": [] },
-              "group_instance_cardinality": { "intervals": [] },
-              "parents": [], 
-              "children": [] 
+        "children": [
+          {
+            "name": "sourdough",
+            "instance_cardinality": {
+              "intervals": [{ "lower": 0, "upper": 1 }]
             },
-            { 
-              "name": "onion", 
-              "instance_cardinality": { "intervals": [{"lower": 0, "upper": 2}] },
-              "group_type_cardinality": { "intervals": [] },
-              "group_instance_cardinality": { "intervals": [] },
-              "parents": [], 
-              "children": [] 
-            }
-          ] 
-        }
-      ]
+            "group_type_cardinality": { "intervals": [] },
+            "group_instance_cardinality": { "intervals": [] },
+            "children": []
+          },
+          {
+            "name": "wheat",
+            "instance_cardinality": {
+              "intervals": [{ "lower": 0, "upper": 1 }]
+            },
+            "group_type_cardinality": { "intervals": [] },
+            "group_instance_cardinality": { "intervals": [] },
+            "children": []
+          }
+        ]
+      },
+      {
+        "name": "cheese-mix",
+        "instance_cardinality": {
+          "intervals": [
+            { "lower": 0, "upper": 0 },
+            { "lower": 2, "upper": 4 }
+          ]
+        },
+        "group_type_cardinality": { "intervals": [{ "lower": 1, "upper": 3 }] },
+        "group_instance_cardinality": {
+          "intervals": [{ "lower": 3, "upper": 3 }]
+        },
+        "children": [
+          {
+            "name": "cheddar",
+            "instance_cardinality": {
+              "intervals": [{ "lower": 0, "upper": 1 }]
+            },
+            "group_type_cardinality": { "intervals": [] },
+            "group_instance_cardinality": { "intervals": [] },
+            "children": []
+          },
+          {
+            "name": "swiss",
+            "instance_cardinality": {
+              "intervals": [{ "lower": 0, "upper": 2 }]
+            },
+            "group_type_cardinality": { "intervals": [] },
+            "group_instance_cardinality": { "intervals": [] },
+            "children": []
+          },
+          {
+            "name": "gouda",
+            "instance_cardinality": {
+              "intervals": [{ "lower": 0, "upper": 3 }]
+            },
+            "group_type_cardinality": { "intervals": [] },
+            "group_instance_cardinality": { "intervals": [] },
+            "children": []
+          }
+        ]
+      },
+      {
+        "name": "veggies",
+        "instance_cardinality": { "intervals": [{ "lower": 0, "upper": 1 }] },
+        "group_type_cardinality": { "intervals": [{ "lower": 1, "upper": 3 }] },
+        "group_instance_cardinality": {
+          "intervals": [{ "lower": 1, "upper": null }]
+        },
+        "children": [
+          {
+            "name": "lettuce",
+            "instance_cardinality": {
+              "intervals": [{ "lower": 0, "upper": null }]
+            },
+            "group_type_cardinality": { "intervals": [] },
+            "group_instance_cardinality": { "intervals": [] },
+            "children": []
+          },
+          {
+            "name": "tomato",
+            "instance_cardinality": {
+              "intervals": [{ "lower": 0, "upper": null }]
+            },
+            "group_type_cardinality": { "intervals": [] },
+            "group_instance_cardinality": { "intervals": [] },
+            "children": []
+          },
+          {
+            "name": "onion",
+            "instance_cardinality": {
+              "intervals": [{ "lower": 0, "upper": 2 }]
+            },
+            "group_type_cardinality": { "intervals": [] },
+            "group_instance_cardinality": { "intervals": [] },
+            "children": []
+          }
+        ]
+      }
+    ]
+  },
+  "constraints": [
+    {
+      "require": true,
+      "first_feature_name": "wheat",
+      "first_cardinality": { "intervals": [{ "lower": 1, "upper": null }] },
+      "second_feature_name": "lettuce",
+      "second_cardinality": { "intervals": [{ "lower": 1, "upper": null }] }
+    },
+    {
+      "require": true,
+      "first_feature_name": "cheddar",
+      "first_cardinality": { "intervals": [{ "lower": 3, "upper": 3 }] },
+      "second_feature_name": "sourdough",
+      "second_cardinality": { "intervals": [{ "lower": 1, "upper": 1 }] }
+    },
+    {
+      "require": false,
+      "first_feature_name": "tomato",
+      "first_cardinality": { "intervals": [{ "lower": 6, "upper": 6 }] },
+      "second_feature_name": "gouda",
+      "second_cardinality": { "intervals": [{ "lower": 2, "upper": null }] }
     }
-  ],
-  "require_constraints": [{
-    "require": true,
-    "first_feature": { 
-      "name": "wheat", 
-      "instance_cardinality": { "intervals": [] },
-      "group_type_cardinality": { "intervals": [] },
-      "group_instance_cardinality": { "intervals": [] },
-      "parents": [], 
-      "children": []  
-    },
-    "first_cardinality": { "intervals": [{"lower": 1, "upper": null}] },
-    "second_feature": { 
-      "name": "lettuce", 
-      "instance_cardinality": { "intervals": [] },
-      "group_type_cardinality": { "intervals": [] },
-      "group_instance_cardinality": { "intervals": [] },
-      "parents": [], 
-      "children": []  
-    },
-    "second_cardinality": { "intervals": [{"lower": 1, "upper": null}] }
-  }, {
-    "require": true,
-    "first_feature": { 
-      "name": "cheddar", 
-      "instance_cardinality": { "intervals": [] },
-      "group_type_cardinality": { "intervals": [] },
-      "group_instance_cardinality": { "intervals": [] },
-      "parents": [], 
-      "children": []  
-    },
-    "first_cardinality": { "intervals": [{"lower": 3, "upper": 3}] },
-    "second_feature": { 
-      "name": "sourdough", 
-      "instance_cardinality": { "intervals": [] },
-      "group_type_cardinality": { "intervals": [] },
-      "group_instance_cardinality": { "intervals": [] },
-      "parents": [], 
-      "children": []  
-    },
-    "second_cardinality": { "intervals": [{"lower": 1, "upper": 1}] }
-  }],
-  "exclude_constraints": [{
-    "require": false,
-    "first_feature": { 
-      "name": "tomato", 
-      "instance_cardinality": { "intervals": [] },
-      "group_type_cardinality": { "intervals": [] },
-      "group_instance_cardinality": { "intervals": [] },
-      "parents": [], 
-      "children": []  
-    },
-    "first_cardinality": { "intervals": [{"lower": 6, "upper": 6}] },
-    "second_feature": { 
-      "name": "gouda", 
-      "instance_cardinality": { "intervals": [] },
-      "group_type_cardinality": { "intervals": [] },
-      "group_instance_cardinality": { "intervals": [] },
-      "parents": [], 
-      "children": []  
-    },
-    "second_cardinality": { "intervals": [{"lower": 2, "upper": null}] }
-  }]
+  ]
 }

--- a/tests/data/sandwich_bound.json
+++ b/tests/data/sandwich_bound.json
@@ -1,299 +1,272 @@
 {
-  "features": [
-    {
-      "name": "sandwich",
-      "instance_cardinality": {
-        "intervals": [
-          {
-            "lower": 1,
-            "upper": 1
-          }
-        ]
-      },
-      "group_type_cardinality": {
-        "intervals": [
-          {
-            "lower": 1,
-            "upper": 3
-          }
-        ]
-      },
-      "group_instance_cardinality": {
-        "intervals": [
-          {
-            "lower": 2,
-            "upper": 7
-          }
-        ]
-      },
-      "parents": [],
-      "children": [
+  "root": {
+    "name": "sandwich",
+    "instance_cardinality": {
+      "intervals": [
         {
-          "name": "bread",
-          "instance_cardinality": {
-            "intervals": [
-              {
-                "lower": 2,
-                "upper": 2
-              }
-            ]
-          },
-          "group_type_cardinality": {
-            "intervals": [
-              {
-                "lower": 1,
-                "upper": 1
-              }
-            ]
-          },
-          "group_instance_cardinality": {
-            "intervals": [
-              {
-                "lower": 1,
-                "upper": 1
-              }
-            ]
-          },
-          "parents": [],
-          "children": [
-            {
-              "name": "sourdough",
-              "instance_cardinality": {
-                "intervals": [
-                  {
-                    "lower": 0,
-                    "upper": 1
-                  }
-                ]
-              },
-              "group_type_cardinality": {
-                "intervals": []
-              },
-              "group_instance_cardinality": {
-                "intervals": []
-              },
-              "parents": [],
-              "children": []
-            },
-            {
-              "name": "wheat",
-              "instance_cardinality": {
-                "intervals": [
-                  {
-                    "lower": 0,
-                    "upper": 1
-                  }
-                ]
-              },
-              "group_type_cardinality": {
-                "intervals": []
-              },
-              "group_instance_cardinality": {
-                "intervals": []
-              },
-              "parents": [],
-              "children": []
-            }
-          ]
-        },
-        {
-          "name": "cheese-mix",
-          "instance_cardinality": {
-            "intervals": [
-              {
-                "lower": 0,
-                "upper": 0
-              },
-              {
-                "lower": 2,
-                "upper": 4
-              }
-            ]
-          },
-          "group_type_cardinality": {
-            "intervals": [
-              {
-                "lower": 1,
-                "upper": 3
-              }
-            ]
-          },
-          "group_instance_cardinality": {
-            "intervals": [
-              {
-                "lower": 3,
-                "upper": 3
-              }
-            ]
-          },
-          "parents": [],
-          "children": [
-            {
-              "name": "cheddar",
-              "instance_cardinality": {
-                "intervals": [
-                  {
-                    "lower": 0,
-                    "upper": 1
-                  }
-                ]
-              },
-              "group_type_cardinality": {
-                "intervals": []
-              },
-              "group_instance_cardinality": {
-                "intervals": []
-              },
-              "parents": [],
-              "children": []
-            },
-            {
-              "name": "swiss",
-              "instance_cardinality": {
-                "intervals": [
-                  {
-                    "lower": 0,
-                    "upper": 2
-                  }
-                ]
-              },
-              "group_type_cardinality": {
-                "intervals": []
-              },
-              "group_instance_cardinality": {
-                "intervals": []
-              },
-              "parents": [],
-              "children": []
-            },
-            {
-              "name": "gouda",
-              "instance_cardinality": {
-                "intervals": [
-                  {
-                    "lower": 0,
-                    "upper": 3
-                  }
-                ]
-              },
-              "group_type_cardinality": {
-                "intervals": []
-              },
-              "group_instance_cardinality": {
-                "intervals": []
-              },
-              "parents": [],
-              "children": []
-            }
-          ]
-        },
-        {
-          "name": "veggies",
-          "instance_cardinality": {
-            "intervals": [
-              {
-                "lower": 0,
-                "upper": 1
-              }
-            ]
-          },
-          "group_type_cardinality": {
-            "intervals": [
-              {
-                "lower": 1,
-                "upper": 3
-              }
-            ]
-          },
-          "group_instance_cardinality": {
-            "intervals": [
-              {
-                "lower": 1,
-                "upper": 26
-              }
-            ]
-          },
-          "parents": [],
-          "children": [
-            {
-              "name": "lettuce",
-              "instance_cardinality": {
-                "intervals": [
-                  {
-                    "lower": 0,
-                    "upper": 12
-                  }
-                ]
-              },
-              "group_type_cardinality": {
-                "intervals": []
-              },
-              "group_instance_cardinality": {
-                "intervals": []
-              },
-              "parents": [],
-              "children": []
-            },
-            {
-              "name": "tomato",
-              "instance_cardinality": {
-                "intervals": [
-                  {
-                    "lower": 0,
-                    "upper": 12
-                  }
-                ]
-              },
-              "group_type_cardinality": {
-                "intervals": []
-              },
-              "group_instance_cardinality": {
-                "intervals": []
-              },
-              "parents": [],
-              "children": []
-            },
-            {
-              "name": "onion",
-              "instance_cardinality": {
-                "intervals": [
-                  {
-                    "lower": 0,
-                    "upper": 2
-                  }
-                ]
-              },
-              "group_type_cardinality": {
-                "intervals": []
-              },
-              "group_instance_cardinality": {
-                "intervals": []
-              },
-              "parents": [],
-              "children": []
-            }
-          ]
+          "lower": 1,
+          "upper": 1
         }
       ]
-    }
-  ],
-  "require_constraints": [
-    {
-      "require": true,
-      "first_feature": {
-        "name": "wheat",
+    },
+    "group_type_cardinality": {
+      "intervals": [
+        {
+          "lower": 1,
+          "upper": 3
+        }
+      ]
+    },
+    "group_instance_cardinality": {
+      "intervals": [
+        {
+          "lower": 2,
+          "upper": 7
+        }
+      ]
+    },
+    "children": [
+      {
+        "name": "bread",
         "instance_cardinality": {
-          "intervals": []
+          "intervals": [
+            {
+              "lower": 2,
+              "upper": 2
+            }
+          ]
         },
         "group_type_cardinality": {
-          "intervals": []
+          "intervals": [
+            {
+              "lower": 1,
+              "upper": 1
+            }
+          ]
         },
         "group_instance_cardinality": {
-          "intervals": []
+          "intervals": [
+            {
+              "lower": 1,
+              "upper": 1
+            }
+          ]
         },
-        "parents": [],
-        "children": []
+        "children": [
+          {
+            "name": "sourdough",
+            "instance_cardinality": {
+              "intervals": [
+                {
+                  "lower": 0,
+                  "upper": 1
+                }
+              ]
+            },
+            "group_type_cardinality": {
+              "intervals": []
+            },
+            "group_instance_cardinality": {
+              "intervals": []
+            },
+            "children": []
+          },
+          {
+            "name": "wheat",
+            "instance_cardinality": {
+              "intervals": [
+                {
+                  "lower": 0,
+                  "upper": 1
+                }
+              ]
+            },
+            "group_type_cardinality": {
+              "intervals": []
+            },
+            "group_instance_cardinality": {
+              "intervals": []
+            },
+            "children": []
+          }
+        ]
       },
+      {
+        "name": "cheese-mix",
+        "instance_cardinality": {
+          "intervals": [
+            {
+              "lower": 0,
+              "upper": 0
+            },
+            {
+              "lower": 2,
+              "upper": 4
+            }
+          ]
+        },
+        "group_type_cardinality": {
+          "intervals": [
+            {
+              "lower": 1,
+              "upper": 3
+            }
+          ]
+        },
+        "group_instance_cardinality": {
+          "intervals": [
+            {
+              "lower": 3,
+              "upper": 3
+            }
+          ]
+        },
+        "children": [
+          {
+            "name": "cheddar",
+            "instance_cardinality": {
+              "intervals": [
+                {
+                  "lower": 0,
+                  "upper": 1
+                }
+              ]
+            },
+            "group_type_cardinality": {
+              "intervals": []
+            },
+            "group_instance_cardinality": {
+              "intervals": []
+            },
+            "children": []
+          },
+          {
+            "name": "swiss",
+            "instance_cardinality": {
+              "intervals": [
+                {
+                  "lower": 0,
+                  "upper": 2
+                }
+              ]
+            },
+            "group_type_cardinality": {
+              "intervals": []
+            },
+            "group_instance_cardinality": {
+              "intervals": []
+            },
+            "children": []
+          },
+          {
+            "name": "gouda",
+            "instance_cardinality": {
+              "intervals": [
+                {
+                  "lower": 0,
+                  "upper": 3
+                }
+              ]
+            },
+            "group_type_cardinality": {
+              "intervals": []
+            },
+            "group_instance_cardinality": {
+              "intervals": []
+            },
+            "children": []
+          }
+        ]
+      },
+      {
+        "name": "veggies",
+        "instance_cardinality": {
+          "intervals": [
+            {
+              "lower": 0,
+              "upper": 1
+            }
+          ]
+        },
+        "group_type_cardinality": {
+          "intervals": [
+            {
+              "lower": 1,
+              "upper": 3
+            }
+          ]
+        },
+        "group_instance_cardinality": {
+          "intervals": [
+            {
+              "lower": 1,
+              "upper": 26
+            }
+          ]
+        },
+        "children": [
+          {
+            "name": "lettuce",
+            "instance_cardinality": {
+              "intervals": [
+                {
+                  "lower": 0,
+                  "upper": 12
+                }
+              ]
+            },
+            "group_type_cardinality": {
+              "intervals": []
+            },
+            "group_instance_cardinality": {
+              "intervals": []
+            },
+            "children": []
+          },
+          {
+            "name": "tomato",
+            "instance_cardinality": {
+              "intervals": [
+                {
+                  "lower": 0,
+                  "upper": 12
+                }
+              ]
+            },
+            "group_type_cardinality": {
+              "intervals": []
+            },
+            "group_instance_cardinality": {
+              "intervals": []
+            },
+            "children": []
+          },
+          {
+            "name": "onion",
+            "instance_cardinality": {
+              "intervals": [
+                {
+                  "lower": 0,
+                  "upper": 2
+                }
+              ]
+            },
+            "group_type_cardinality": {
+              "intervals": []
+            },
+            "group_instance_cardinality": {
+              "intervals": []
+            },
+            "children": []
+          }
+        ]
+      }
+    ]
+  },
+  "constraints": [
+    {
+      "require": true,
+      "first_feature_name": "wheat",
       "first_cardinality": {
         "intervals": [
           {
@@ -302,20 +275,7 @@
           }
         ]
       },
-      "second_feature": {
-        "name": "lettuce",
-        "instance_cardinality": {
-          "intervals": []
-        },
-        "group_type_cardinality": {
-          "intervals": []
-        },
-        "group_instance_cardinality": {
-          "intervals": []
-        },
-        "parents": [],
-        "children": []
-      },
+      "second_feature_name": "lettuce",
       "second_cardinality": {
         "intervals": [
           {
@@ -327,20 +287,7 @@
     },
     {
       "require": true,
-      "first_feature": {
-        "name": "cheddar",
-        "instance_cardinality": {
-          "intervals": []
-        },
-        "group_type_cardinality": {
-          "intervals": []
-        },
-        "group_instance_cardinality": {
-          "intervals": []
-        },
-        "parents": [],
-        "children": []
-      },
+      "first_feature_name": "cheddar",
       "first_cardinality": {
         "intervals": [
           {
@@ -349,20 +296,7 @@
           }
         ]
       },
-      "second_feature": {
-        "name": "sourdough",
-        "instance_cardinality": {
-          "intervals": []
-        },
-        "group_type_cardinality": {
-          "intervals": []
-        },
-        "group_instance_cardinality": {
-          "intervals": []
-        },
-        "parents": [],
-        "children": []
-      },
+      "second_feature_name": "sourdough",
       "second_cardinality": {
         "intervals": [
           {
@@ -371,25 +305,10 @@
           }
         ]
       }
-    }
-  ],
-  "exclude_constraints": [
+    },
     {
       "require": false,
-      "first_feature": {
-        "name": "tomato",
-        "instance_cardinality": {
-          "intervals": []
-        },
-        "group_type_cardinality": {
-          "intervals": []
-        },
-        "group_instance_cardinality": {
-          "intervals": []
-        },
-        "parents": [],
-        "children": []
-      },
+      "first_feature_name": "tomato",
       "first_cardinality": {
         "intervals": [
           {
@@ -398,20 +317,7 @@
           }
         ]
       },
-      "second_feature": {
-        "name": "gouda",
-        "instance_cardinality": {
-          "intervals": []
-        },
-        "group_type_cardinality": {
-          "intervals": []
-        },
-        "group_instance_cardinality": {
-          "intervals": []
-        },
-        "parents": [],
-        "children": []
-      },
+      "second_feature_name": "gouda",
       "second_cardinality": {
         "intervals": [
           {

--- a/tests/plugins/test_json_export.py
+++ b/tests/plugins/test_json_export.py
@@ -1,20 +1,176 @@
 import json
 
-import cfmtoolbox.plugins.json_export as json_export_plugin
-from cfmtoolbox import CFM
-from cfmtoolbox.plugins.json_export import export_json
+from cfmtoolbox import CFM, Cardinality, Constraint, Feature, Interval
+from cfmtoolbox.plugins import json_export
 from cfmtoolbox.toolbox import CFMToolbox
 
 
 def test_plugin_can_be_loaded():
     app = CFMToolbox()
-    assert json_export_plugin in app.load_plugins()
+    assert json_export in app.load_plugins()
 
 
-def test_json_export():
-    cfm = CFM([], [], [])
-    output = export_json(cfm)
-
-    assert output.decode() == json.dumps(
-        {"features": [], "require_constraints": [], "exclude_constraints": []}, indent=2
+def test_export_json():
+    root = Feature(
+        name="sandwich",
+        instance_cardinality=Cardinality(intervals=[]),
+        group_type_cardinality=Cardinality(intervals=[]),
+        group_instance_cardinality=Cardinality(intervals=[]),
+        parents=[],
+        children=[],
     )
+
+    cfm = CFM(
+        features=[root],
+        require_constraints=[],
+        exclude_constraints=[],
+    )
+
+    output = json_export.export_json(cfm)
+    assert output.decode() == json.dumps(
+        {
+            "root": {
+                "name": "sandwich",
+                "instance_cardinality": {"intervals": []},
+                "group_type_cardinality": {"intervals": []},
+                "group_instance_cardinality": {"intervals": []},
+                "children": [],
+            },
+            "constraints": [],
+        },
+        indent=2,
+    )
+
+
+def test_serialize_feature_can_serialize_standalone_features():
+    feature = Feature(
+        name="sandwich",
+        instance_cardinality=Cardinality(intervals=[]),
+        group_type_cardinality=Cardinality(intervals=[]),
+        group_instance_cardinality=Cardinality(intervals=[]),
+        parents=[],
+        children=[],
+    )
+
+    serialized_feature = json_export.serialize_feature(feature)
+    assert serialized_feature == {
+        "name": "sandwich",
+        "instance_cardinality": {"intervals": []},
+        "group_type_cardinality": {"intervals": []},
+        "group_instance_cardinality": {"intervals": []},
+        "children": [],
+    }
+
+
+def test_serialize_feature_can_serialize_children():
+    sandwich = Feature(
+        name="sandwich",
+        instance_cardinality=Cardinality(intervals=[]),
+        group_type_cardinality=Cardinality(intervals=[]),
+        group_instance_cardinality=Cardinality(intervals=[]),
+        parents=[],
+        children=[],
+    )
+
+    bread = Feature(
+        name="bread",
+        instance_cardinality=Cardinality(intervals=[]),
+        group_type_cardinality=Cardinality(intervals=[]),
+        group_instance_cardinality=Cardinality(intervals=[]),
+        parents=[sandwich],
+        children=[],
+    )
+
+    sandwich.children = [bread]
+
+    serialized_feature = json_export.serialize_feature(sandwich)
+    assert serialized_feature == {
+        "name": "sandwich",
+        "instance_cardinality": {"intervals": []},
+        "group_type_cardinality": {"intervals": []},
+        "group_instance_cardinality": {"intervals": []},
+        "children": [
+            {
+                "name": "bread",
+                "instance_cardinality": {"intervals": []},
+                "group_type_cardinality": {"intervals": []},
+                "group_instance_cardinality": {"intervals": []},
+                "children": [],
+            }
+        ],
+    }
+
+
+def test_serialize_cardinality_can_serialize_empty_intervals():
+    cardinality = Cardinality(intervals=[])
+    serialized_cardinality = json_export.serialize_cardinality(cardinality)
+    assert serialized_cardinality == {"intervals": []}
+
+
+def test_serialize_cardinality_can_serialize_multiple_intervals():
+    cardinality = Cardinality(
+        intervals=[
+            Interval(lower=0, upper=0),
+            Interval(lower=1, upper=2),
+            Interval(lower=2, upper=None),
+        ]
+    )
+
+    serialized_cardinality = json_export.serialize_cardinality(cardinality)
+    assert serialized_cardinality == {
+        "intervals": [
+            {"lower": 0, "upper": 0},
+            {"lower": 1, "upper": 2},
+            {"lower": 2, "upper": None},
+        ]
+    }
+
+
+def test_serialize_interval_can_serialize_bound_interval():
+    interval = Interval(lower=0, upper=0)
+    serialized_interval = json_export.serialize_interval(interval)
+    assert serialized_interval == {"lower": 0, "upper": 0}
+
+
+def test_serialize_interval_can_serialize_unbound_interval():
+    interval = Interval(lower=2, upper=None)
+    serialized_interval = json_export.serialize_interval(interval)
+    assert serialized_interval == {"lower": 2, "upper": None}
+
+
+def test_serialize_constraint():
+    feature1 = Feature(
+        name="nuggets",
+        instance_cardinality=Cardinality(intervals=[]),
+        group_type_cardinality=Cardinality(intervals=[]),
+        group_instance_cardinality=Cardinality(intervals=[]),
+        parents=[],
+        children=[],
+    )
+
+    feature2 = Feature(
+        name="sauce",
+        instance_cardinality=Cardinality(intervals=[]),
+        group_type_cardinality=Cardinality(intervals=[]),
+        group_instance_cardinality=Cardinality(intervals=[]),
+        parents=[],
+        children=[],
+    )
+
+    constraint = json_export.serialize_constraint(
+        Constraint(
+            require=True,
+            first_feature=feature1,
+            first_cardinality=Cardinality(intervals=[]),
+            second_feature=feature2,
+            second_cardinality=Cardinality(intervals=[]),
+        )
+    )
+
+    assert constraint == {
+        "require": True,
+        "first_feature_name": "nuggets",
+        "first_cardinality": {"intervals": []},
+        "second_feature_name": "sauce",
+        "second_cardinality": {"intervals": []},
+    }

--- a/tests/plugins/test_json_import.py
+++ b/tests/plugins/test_json_import.py
@@ -1,153 +1,685 @@
+from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
 
-import cfmtoolbox.plugins.json_import as json_import_plugin
-from cfmtoolbox.plugins.json_import import (
-    JSON,
-    import_json,
-    parse_cardinality,
-    parse_cfm,
-    parse_constraint,
-    parse_feature,
-    parse_interval,
-)
-from cfmtoolbox.toolbox import CFMToolbox
+from cfmtoolbox import Cardinality, CFMToolbox, Constraint, Feature, Interval
+from cfmtoolbox.plugins import json_import
 
 
 def test_plugin_can_be_loaded():
     app = CFMToolbox()
-    assert json_import_plugin in app.load_plugins()
+    assert json_import in app.load_plugins()
 
 
-def test_json_import():
+def test_import_json():
     path = Path("tests/data/sandwich.json")
-    cfm = import_json(path.read_bytes())
-    assert len(cfm.features) == 1
+    cfm = json_import.import_json(path.read_bytes())
+    assert len(cfm.features) == 12
     assert cfm.features[0].name == "sandwich"
 
 
-def test_parsing_a_complex_cfm():
-    cfm = parse_cfm(
+@pytest.mark.parametrize(
+    ("cfm", "expectation"),
+    [
+        ([], pytest.raises(TypeError, match="CFM must be an object")),
+        ("string", pytest.raises(TypeError, match="CFM must be an object")),
+        (1, pytest.raises(TypeError, match="CFM must be an object")),
+        (1.0, pytest.raises(TypeError, match="CFM must be an object")),
+        (True, pytest.raises(TypeError, match="CFM must be an object")),
+        (False, pytest.raises(TypeError, match="CFM must be an object")),
+        (None, pytest.raises(TypeError, match="CFM must be an object")),
+        ({}, pytest.raises(KeyError, match="constraints")),
+    ],
+)
+def test_parse_cfm_requires_cfm_to_be_an_object(cfm, expectation):
+    with expectation:
+        json_import.parse_cfm(cfm)
+
+
+@pytest.mark.parametrize(
+    ("constraints", "expectation"),
+    [
+        ({}, pytest.raises(TypeError, match="CFM constraints must be a list")),
+        ("string", pytest.raises(TypeError, match="CFM constraints must be a list")),
+        (1, pytest.raises(TypeError, match="CFM constraints must be a list")),
+        (1.0, pytest.raises(TypeError, match="CFM constraints must be a list")),
+        (True, pytest.raises(TypeError, match="CFM constraints must be a list")),
+        (False, pytest.raises(TypeError, match="CFM constraints must be a list")),
+        (None, pytest.raises(TypeError, match="CFM constraints must be a list")),
+        ([], pytest.raises(KeyError, match="name")),
+    ],
+)
+def test_parse_cfm_requires_constraints_to_be_a_list(constraints, expectation):
+    with expectation:
+        json_import.parse_cfm({"root": {}, "constraints": constraints})
+
+
+def test_parse_cfm_parses_root_and_constraints():
+    cfm = json_import.parse_cfm(
         {
-            "features": [
-                {
-                    "name": "sandwich",
-                    "instance_cardinality": {"intervals": [{"lower": 1, "upper": 1}]},
-                    "group_type_cardinality": {"intervals": [{"lower": 1, "upper": 1}]},
-                    "group_instance_cardinality": {
-                        "intervals": [{"lower": 1, "upper": 1}]
+            "root": {
+                "name": "sandwich",
+                "instance_cardinality": {"intervals": []},
+                "group_type_cardinality": {"intervals": []},
+                "group_instance_cardinality": {"intervals": []},
+                "children": [
+                    {
+                        "name": "bread",
+                        "instance_cardinality": {"intervals": []},
+                        "group_type_cardinality": {"intervals": []},
+                        "group_instance_cardinality": {"intervals": []},
+                        "children": [],
                     },
-                    "parents": [],
-                    "children": [],
-                }
+                    {
+                        "name": "protein",
+                        "instance_cardinality": {"intervals": []},
+                        "group_type_cardinality": {"intervals": []},
+                        "group_instance_cardinality": {"intervals": []},
+                        "children": [],
+                    },
+                    {
+                        "name": "veggies",
+                        "instance_cardinality": {"intervals": []},
+                        "group_type_cardinality": {"intervals": []},
+                        "group_instance_cardinality": {"intervals": []},
+                        "children": [],
+                    },
+                ],
+            },
+            "constraints": [
+                {
+                    "require": True,
+                    "first_feature_name": "bread",
+                    "first_cardinality": {"intervals": []},
+                    "second_feature_name": "protein",
+                    "second_cardinality": {"intervals": []},
+                },
+                {
+                    "require": True,
+                    "first_feature_name": "protein",
+                    "first_cardinality": {"intervals": []},
+                    "second_feature_name": "bread",
+                    "second_cardinality": {"intervals": []},
+                },
+                {
+                    "require": False,
+                    "first_feature_name": "protein",
+                    "first_cardinality": {"intervals": []},
+                    "second_feature_name": "veggies",
+                    "second_cardinality": {"intervals": []},
+                },
             ],
-            "require_constraints": [],
-            "exclude_constraints": [],
         }
     )
 
-    assert len(cfm.features) == 1
-    assert cfm.features[0].name == "sandwich"
-    assert cfm.features[0].instance_cardinality.intervals[0].lower == 1
-    assert cfm.features[0].instance_cardinality.intervals[0].upper == 1
-    assert cfm.features[0].group_type_cardinality.intervals[0].lower == 1
-    assert cfm.features[0].group_type_cardinality.intervals[0].upper == 1
-    assert cfm.features[0].group_instance_cardinality.intervals[0].lower == 1
-    assert cfm.features[0].group_instance_cardinality.intervals[0].upper == 1
-    assert len(cfm.features[0].parents) == 0
-    assert len(cfm.features[0].children) == 0
-    assert len(cfm.require_constraints) == 0
-    assert len(cfm.exclude_constraints) == 0
+    assert len(cfm.features) == 4
+    assert len(cfm.require_constraints) == 2
+    assert len(cfm.exclude_constraints) == 1
 
 
-@pytest.mark.parametrize("data", [[], "string", 1, 1.0, True, False, None])
-def test_cfm_must_be_an_object(data: JSON):
-    with pytest.raises(TypeError, match="CFM must be an object"):
-        parse_cfm(data)
+def test_parse_root_returns_all_features_in_the_tree():
+    features = json_import.parse_root(
+        {
+            "name": "sandwich",
+            "instance_cardinality": {"intervals": []},
+            "group_type_cardinality": {"intervals": []},
+            "group_instance_cardinality": {"intervals": []},
+            "parents": [],
+            "children": [
+                {
+                    "name": "meat",
+                    "instance_cardinality": {"intervals": []},
+                    "group_type_cardinality": {"intervals": []},
+                    "group_instance_cardinality": {"intervals": []},
+                    "parents": [],
+                    "children": [],
+                },
+                {
+                    "name": "bread",
+                    "instance_cardinality": {"intervals": []},
+                    "group_type_cardinality": {"intervals": []},
+                    "group_instance_cardinality": {"intervals": []},
+                    "parents": [],
+                    "children": [
+                        {
+                            "name": "sourdough",
+                            "instance_cardinality": {"intervals": []},
+                            "group_type_cardinality": {"intervals": []},
+                            "group_instance_cardinality": {"intervals": []},
+                            "parents": [],
+                            "children": [],
+                        },
+                        {
+                            "name": "wheat",
+                            "instance_cardinality": {"intervals": []},
+                            "group_type_cardinality": {"intervals": []},
+                            "group_instance_cardinality": {"intervals": []},
+                            "parents": [],
+                            "children": [],
+                        },
+                    ],
+                },
+            ],
+        }
+    )
+
+    assert len(features) == 5
+    assert features[0].name == "sandwich"
+    assert features[1].name == "meat"
+    assert features[2].name == "bread"
+    assert features[3].name == "sourdough"
+    assert features[4].name == "wheat"
 
 
-@pytest.mark.parametrize("data", [{}, "string", 1, 1.0, True, False, None])
-def test_cfm_features_must_be_a_list(data: JSON):
-    with pytest.raises(TypeError, match="CFM feature must be a list"):
-        parse_cfm({"features": data})
+@pytest.mark.parametrize(
+    ("feature", "expectation"),
+    [
+        ([], pytest.raises(TypeError, match="Feature must be an object")),
+        ("string", pytest.raises(TypeError, match="Feature must be an object")),
+        (1, pytest.raises(TypeError, match="Feature must be an object")),
+        (1.0, pytest.raises(TypeError, match="Feature must be an object")),
+        (True, pytest.raises(TypeError, match="Feature must be an object")),
+        (False, pytest.raises(TypeError, match="Feature must be an object")),
+        (None, pytest.raises(TypeError, match="Feature must be an object")),
+        ({}, pytest.raises(KeyError, match="name")),
+    ],
+)
+def test_parse_feature_requires_feature_to_be_an_object(feature, expectation):
+    with expectation:
+        json_import.parse_feature(feature, [])
 
 
-@pytest.mark.parametrize("data", [{}, "string", 1, 1.0, True, False, None])
-def test_cfm_require_constraints_must_be_a_list(data: JSON):
-    with pytest.raises(TypeError, match="CFM require constraints must be a list"):
-        parse_cfm({"features": [], "require_constraints": data})
+@pytest.mark.parametrize(
+    ("name", "expectation"),
+    [
+        ({}, pytest.raises(TypeError, match="Feature name must be a string")),
+        ([], pytest.raises(TypeError, match="Feature name must be a string")),
+        (1, pytest.raises(TypeError, match="Feature name must be a string")),
+        (1.0, pytest.raises(TypeError, match="Feature name must be a string")),
+        (True, pytest.raises(TypeError, match="Feature name must be a string")),
+        (False, pytest.raises(TypeError, match="Feature name must be a string")),
+        (None, pytest.raises(TypeError, match="Feature name must be a string")),
+        ("string", pytest.raises(KeyError, match="children")),
+    ],
+)
+def test_parse_feature_requires_name_to_be_a_string(name, expectation):
+    with expectation:
+        json_import.parse_feature({"name": name}, parents=[])
 
 
-@pytest.mark.parametrize("data", [{}, "string", 1, 1.0, True, False, None])
-def test_cfm_exclude_constraints_must_be_a_list(data: JSON):
-    with pytest.raises(TypeError, match="CFM exclude constraints must be a list"):
-        parse_cfm(
-            {"features": [], "require_constraints": [], "exclude_constraints": data}
+@pytest.mark.parametrize(
+    ("children", "expectation"),
+    [
+        ({}, pytest.raises(TypeError, match="Feature children must be a list")),
+        ("string", pytest.raises(TypeError, match="Feature children must be a list")),
+        (1, pytest.raises(TypeError, match="Feature children must be a list")),
+        (1.0, pytest.raises(TypeError, match="Feature children must be a list")),
+        (True, pytest.raises(TypeError, match="Feature children must be a list")),
+        (False, pytest.raises(TypeError, match="Feature children must be a list")),
+        (None, pytest.raises(TypeError, match="Feature children must be a list")),
+        ([], pytest.raises(KeyError, match="instance_cardinality")),
+    ],
+)
+def test_parse_feature_requires_children_to_be_a_list(children, expectation):
+    with expectation:
+        json_import.parse_feature(
+            {"name": "name", "parents": [], "children": children}, []
         )
 
 
-@pytest.mark.parametrize("data", [[], "string", 1, 1.0, True, False, None])
-def test_feature_must_be_an_object(data: JSON):
-    with pytest.raises(TypeError, match="Feature must be an object"):
-        parse_feature(data)
+def test_parse_feature_parses_features_and_adds_relatives():
+    feature = json_import.parse_feature(
+        {
+            "name": "sandwich",
+            "instance_cardinality": {"intervals": []},
+            "group_type_cardinality": {"intervals": []},
+            "group_instance_cardinality": {"intervals": []},
+            "children": [
+                {
+                    "name": "bread",
+                    "instance_cardinality": {"intervals": []},
+                    "group_type_cardinality": {"intervals": []},
+                    "group_instance_cardinality": {"intervals": []},
+                    "children": [],
+                }
+            ],
+        },
+        [],
+    )
+
+    assert feature.name == "sandwich"
+    assert feature.instance_cardinality == Cardinality(intervals=[])
+    assert feature.group_type_cardinality == Cardinality(intervals=[])
+    assert feature.group_instance_cardinality == Cardinality(intervals=[])
+    assert len(feature.parents) == 0
+    assert len(feature.children) == 1
+
+    child = feature.children[0]
+    assert child.name == "bread"
+    assert child.instance_cardinality == Cardinality(intervals=[])
+    assert child.group_type_cardinality == Cardinality(intervals=[])
+    assert child.group_instance_cardinality == Cardinality(intervals=[])
+    assert child.parents == [feature]
+    assert len(child.children) == 0
 
 
-@pytest.mark.parametrize("data", [{}, [], 1, 1.0, True, False, None])
-def test_feature_name_must_be_a_string(data: JSON):
-    with pytest.raises(TypeError, match="Feature name must be a string"):
-        parse_feature({"name": data, "parents": [], "children": []})
+@pytest.mark.parametrize(
+    ("cardinality", "expectation"),
+    [
+        ([], pytest.raises(TypeError, match="Cardinality must be an object")),
+        ("string", pytest.raises(TypeError, match="Cardinality must be an object")),
+        (1, pytest.raises(TypeError, match="Cardinality must be an object")),
+        (1.0, pytest.raises(TypeError, match="Cardinality must be an object")),
+        (True, pytest.raises(TypeError, match="Cardinality must be an object")),
+        (False, pytest.raises(TypeError, match="Cardinality must be an object")),
+        (None, pytest.raises(TypeError, match="Cardinality must be an object")),
+        ({}, pytest.raises(KeyError, match="intervals")),
+    ],
+)
+def test_parse_cardinality_requires_cardinality_to_be_an_object(
+    cardinality, expectation
+):
+    with expectation:
+        json_import.parse_cardinality(cardinality)
 
 
-@pytest.mark.parametrize("data", [{}, "string", 1, 1.0, True, False, None])
-def test_feature_parent_must_be_a_list(data: JSON):
-    with pytest.raises(TypeError, match="Feature parents must be a list"):
-        parse_feature({"name": "name", "parents": "string", "children": data})
+@pytest.mark.parametrize(
+    ("intervals", "expectation"),
+    [
+        ({}, pytest.raises(TypeError, match="Cardinality intervals must be a list")),
+        ("", pytest.raises(TypeError, match="Cardinality intervals must be a list")),
+        (1, pytest.raises(TypeError, match="Cardinality intervals must be a list")),
+        (1.0, pytest.raises(TypeError, match="Cardinality intervals must be a list")),
+        (True, pytest.raises(TypeError, match="Cardinality intervals must be a list")),
+        (False, pytest.raises(TypeError, match="Cardinality intervals must be a list")),
+        (None, pytest.raises(TypeError, match="Cardinality intervals must be a list")),
+        ([], nullcontext()),
+    ],
+)
+def test_parse_cardinality_requires_intervals_to_be_a_list(intervals, expectation):
+    with expectation:
+        json_import.parse_cardinality({"intervals": intervals})
 
 
-@pytest.mark.parametrize("data", [{}, "string", 1, 1.0, True, False, None])
-def test_feature_children_must_be_a_list(data: JSON):
-    with pytest.raises(TypeError, match="Feature children must be a list"):
-        parse_feature({"name": "name", "parents": [], "children": data})
+def test_parse_cardinality_returns_parsed_cardinality():
+    cardinality = json_import.parse_cardinality(
+        {
+            "intervals": [
+                {"lower": 0, "upper": 1},
+                {"lower": 1, "upper": 1},
+                {"lower": 1, "upper": None},
+            ]
+        }
+    )
+
+    assert cardinality == Cardinality(
+        intervals=[
+            Interval(lower=0, upper=1),
+            Interval(lower=1, upper=1),
+            Interval(lower=1, upper=None),
+        ]
+    )
 
 
-@pytest.mark.parametrize("data", [[], "string", 1, 1.0, True, False, None])
-def test_cardinality_must_be_an_object(data: JSON):
-    with pytest.raises(TypeError, match="Cardinality must be an object"):
-        parse_cardinality(data)
+@pytest.mark.parametrize(
+    ("interval", "expectation"),
+    [
+        ([], pytest.raises(TypeError, match="Interval must be an object")),
+        ("string", pytest.raises(TypeError, match="Interval must be an object")),
+        (1, pytest.raises(TypeError, match="Interval must be an object")),
+        (1.0, pytest.raises(TypeError, match="Interval must be an object")),
+        (True, pytest.raises(TypeError, match="Interval must be an object")),
+        (False, pytest.raises(TypeError, match="Interval must be an object")),
+        (None, pytest.raises(TypeError, match="Interval must be an object")),
+        ({}, pytest.raises(KeyError, match="lower")),
+    ],
+)
+def test_parse_interval_requires_interval_to_be_an_object(interval, expectation):
+    with expectation:
+        json_import.parse_interval(interval)
 
 
-@pytest.mark.parametrize("data", [{}, "string", 1, 1.0, True, False, None])
-def test_cardinality_intervals_must_be_a_list(data: JSON):
-    with pytest.raises(TypeError, match="Cardinality intervals must be a list"):
-        parse_cardinality({"intervals": data})
+@pytest.mark.parametrize(
+    ("lower", "expectation"),
+    [
+        ({}, pytest.raises(TypeError, match="Interval lower must be an integer")),
+        ([], pytest.raises(TypeError, match="Interval lower must be an integer")),
+        ("string", pytest.raises(TypeError, match="Interval lower must be an integer")),
+        (1.0, pytest.raises(TypeError, match="Interval lower must be an integer")),
+        (True, pytest.raises(TypeError, match="Interval lower must be an integer")),
+        (False, pytest.raises(TypeError, match="Interval lower must be an integer")),
+        (None, pytest.raises(TypeError, match="Interval lower must be an integer")),
+        (0, nullcontext()),
+        (1, nullcontext()),
+        (22, nullcontext()),
+    ],
+)
+def test_parse_interval_requires_lower_to_be_an_integer(lower, expectation):
+    with expectation:
+        json_import.parse_interval({"lower": lower, "upper": 1})
 
 
-@pytest.mark.parametrize("data", [[], "string", 1, 1.0, True, False, None])
-def test_constraint_must_be_an_object(data: JSON):
-    with pytest.raises(TypeError, match="Constraint must be an object"):
-        parse_constraint(data)
+@pytest.mark.parametrize(
+    ("upper", "expectation"),
+    [
+        (
+            {},
+            pytest.raises(TypeError, match="Interval upper must be an integer or null"),
+        ),
+        (
+            [],
+            pytest.raises(TypeError, match="Interval upper must be an integer or null"),
+        ),
+        (
+            "string",
+            pytest.raises(TypeError, match="Interval upper must be an integer or null"),
+        ),
+        (
+            1.0,
+            pytest.raises(TypeError, match="Interval upper must be an integer or null"),
+        ),
+        (
+            True,
+            pytest.raises(TypeError, match="Interval upper must be an integer or null"),
+        ),
+        (
+            False,
+            pytest.raises(TypeError, match="Interval upper must be an integer or null"),
+        ),
+        (
+            0,
+            nullcontext(),
+        ),
+        (
+            1,
+            nullcontext(),
+        ),
+        (
+            22,
+            nullcontext(),
+        ),
+        (
+            None,
+            nullcontext(),
+        ),
+    ],
+)
+def test_parse_interval_requires_upper_to_be_an_integer_or_null(upper, expectation):
+    with expectation:
+        json_import.parse_interval({"lower": 1, "upper": upper})
 
 
-@pytest.mark.parametrize("data", [{}, [], "string", 1, 1.0, None])
-def test_constraint_require_must_be_a_boolean(data: JSON):
-    with pytest.raises(TypeError, match="Constraint require must be a boolean"):
-        parse_constraint({"require": data})
+def test_parse_interval_can_parse_bound_intervals():
+    interval = json_import.parse_interval({"lower": 1, "upper": 2})
+    assert interval == Interval(lower=1, upper=2)
 
 
-@pytest.mark.parametrize("data", [[], "string", 1, 1.0, True, False, None])
-def test_interval_must_be_an_object(data: JSON):
-    with pytest.raises(TypeError, match="Interval must be an object"):
-        parse_interval(data)
+def test_parse_interval_can_parse_unbound_intervals():
+    interval = json_import.parse_interval({"lower": 1, "upper": None})
+    assert interval == Interval(lower=1, upper=None)
 
 
-@pytest.mark.parametrize("data", [{}, [], "string", 1.0, True, False, None])
-def test_interval_lower_must_be_a_number_null_or_an_integer(data: JSON):
-    with pytest.raises(TypeError, match="Interval lower must be an integer"):
-        parse_interval({"lower": data, "upper": 1})
+@pytest.mark.parametrize(
+    ("constraint", "expectation"),
+    [
+        ([], pytest.raises(TypeError, match="Constraint must be an object")),
+        ("string", pytest.raises(TypeError, match="Constraint must be an object")),
+        (1, pytest.raises(TypeError, match="Constraint must be an object")),
+        (1.0, pytest.raises(TypeError, match="Constraint must be an object")),
+        (True, pytest.raises(TypeError, match="Constraint must be an object")),
+        (False, pytest.raises(TypeError, match="Constraint must be an object")),
+        (None, pytest.raises(TypeError, match="Constraint must be an object")),
+        ({}, pytest.raises(KeyError, match="require")),
+    ],
+)
+def test_parse_constraint_requires_constraint_to_be_an_object(constraint, expectation):
+    with expectation:
+        json_import.parse_constraint(constraint, [])
 
 
-@pytest.mark.parametrize("data", [{}, [], "string", 1.0, True, False])
-def test_interval_upper_must_be_a_number_null_or_an_integer(data: JSON):
-    with pytest.raises(TypeError, match="Interval lower must be null or an integer"):
-        parse_interval({"lower": 1, "upper": data})
+@pytest.mark.parametrize(
+    ("require", "expectation"),
+    [
+        ({}, pytest.raises(TypeError, match="Constraint require must be a boolean")),
+        ([], pytest.raises(TypeError, match="Constraint require must be a boolean")),
+        (
+            "string",
+            pytest.raises(TypeError, match="Constraint require must be a boolean"),
+        ),
+        (1, pytest.raises(TypeError, match="Constraint require must be a boolean")),
+        (1.0, pytest.raises(TypeError, match="Constraint require must be a boolean")),
+        (None, pytest.raises(TypeError, match="Constraint require must be a boolean")),
+        (True, pytest.raises(KeyError, match="first_feature_name")),
+        (False, pytest.raises(KeyError, match="first_feature_name")),
+    ],
+)
+def test_parse_constraint_requires_require_to_be_a_boolean(require, expectation):
+    with expectation:
+        json_import.parse_constraint({"require": require}, [])
+
+
+@pytest.mark.parametrize(
+    ("first_feature_name", "expectation"),
+    [
+        (
+            {},
+            pytest.raises(
+                TypeError, match="Constraint first feature name must be a str"
+            ),
+        ),
+        (
+            [],
+            pytest.raises(
+                TypeError, match="Constraint first feature name must be a str"
+            ),
+        ),
+        (
+            1,
+            pytest.raises(
+                TypeError, match="Constraint first feature name must be a str"
+            ),
+        ),
+        (
+            1.0,
+            pytest.raises(
+                TypeError, match="Constraint first feature name must be a str"
+            ),
+        ),
+        (
+            True,
+            pytest.raises(
+                TypeError, match="Constraint first feature name must be a str"
+            ),
+        ),
+        (
+            False,
+            pytest.raises(
+                TypeError, match="Constraint first feature name must be a str"
+            ),
+        ),
+        (
+            None,
+            pytest.raises(
+                TypeError, match="Constraint first feature name must be a str"
+            ),
+        ),
+        (
+            "feature1",
+            pytest.raises(KeyError, match="second_feature_name"),
+        ),
+    ],
+)
+def test_parse_constraint_requires_first_feature_name_to_be_a_string(
+    first_feature_name, expectation
+):
+    with expectation:
+        json_import.parse_constraint(
+            {"require": True, "first_feature_name": first_feature_name}, []
+        )
+
+
+@pytest.mark.parametrize(
+    ("second_feature_name", "expectation"),
+    [
+        (
+            {},
+            pytest.raises(
+                TypeError, match="Constraint second feature name must be a str"
+            ),
+        ),
+        (
+            [],
+            pytest.raises(
+                TypeError, match="Constraint second feature name must be a str"
+            ),
+        ),
+        (
+            1,
+            pytest.raises(
+                TypeError, match="Constraint second feature name must be a str"
+            ),
+        ),
+        (
+            1.0,
+            pytest.raises(
+                TypeError, match="Constraint second feature name must be a str"
+            ),
+        ),
+        (
+            True,
+            pytest.raises(
+                TypeError, match="Constraint second feature name must be a str"
+            ),
+        ),
+        (
+            False,
+            pytest.raises(
+                TypeError, match="Constraint second feature name must be a str"
+            ),
+        ),
+        (
+            None,
+            pytest.raises(
+                TypeError, match="Constraint second feature name must be a str"
+            ),
+        ),
+        ("feature2", pytest.raises(ValueError, match="Feature feature1 not found")),
+    ],
+)
+def test_parse_constraint_requires_second_feature_name_to_be_a_string(
+    second_feature_name, expectation
+):
+    with expectation:
+        json_import.parse_constraint(
+            {
+                "require": True,
+                "first_feature_name": "feature1",
+                "first_cardinality": {"intervals": []},
+                "second_feature_name": second_feature_name,
+                "second_cardinality": {"intervals": []},
+            },
+            [],
+        )
+
+
+def test_parse_constraint_returns_constraint_with_inserted_features():
+    features = [
+        Feature(
+            name="feature1",
+            instance_cardinality=Cardinality(intervals=[]),
+            group_type_cardinality=Cardinality(intervals=[]),
+            group_instance_cardinality=Cardinality(intervals=[]),
+            parents=[],
+            children=[],
+        ),
+        Feature(
+            name="feature2",
+            instance_cardinality=Cardinality(intervals=[]),
+            group_type_cardinality=Cardinality(intervals=[]),
+            group_instance_cardinality=Cardinality(intervals=[]),
+            parents=[],
+            children=[],
+        ),
+    ]
+
+    constraint = json_import.parse_constraint(
+        {
+            "require": True,
+            "first_feature_name": "feature1",
+            "first_cardinality": {"intervals": []},
+            "second_feature_name": "feature2",
+            "second_cardinality": {"intervals": []},
+        },
+        features,
+    )
+
+    assert constraint == Constraint(
+        require=True,
+        first_feature=features[0],
+        first_cardinality=Cardinality(intervals=[]),
+        second_feature=features[1],
+        second_cardinality=Cardinality(intervals=[]),
+    )
+
+
+def test_parse_constraint_requires_named_features_to_exist():
+    features = [
+        Feature(
+            name="feature1",
+            instance_cardinality=Cardinality(intervals=[]),
+            group_type_cardinality=Cardinality(intervals=[]),
+            group_instance_cardinality=Cardinality(intervals=[]),
+            parents=[],
+            children=[],
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="Feature feature2 not found"):
+        json_import.parse_constraint(
+            {
+                "require": True,
+                "first_feature_name": "feature1",
+                "first_cardinality": {"intervals": []},
+                "second_feature_name": "feature2",
+                "second_cardinality": {"intervals": []},
+            },
+            features,
+        )
+
+
+def test_require_feature_returns_first_match():
+    feature1 = Feature(
+        name="feature1",
+        instance_cardinality=Cardinality(intervals=[]),
+        group_type_cardinality=Cardinality(intervals=[]),
+        group_instance_cardinality=Cardinality(intervals=[]),
+        parents=[],
+        children=[],
+    )
+
+    feature2 = Feature(
+        name="feature2",
+        instance_cardinality=Cardinality(intervals=[]),
+        group_type_cardinality=Cardinality(intervals=[]),
+        group_instance_cardinality=Cardinality(intervals=[]),
+        parents=[],
+        children=[],
+    )
+
+    feature = json_import.require_feature("feature2", [feature1, feature2])
+    assert feature == feature2
+
+
+def test_require_feature_raises_error_when_there_is_no_match():
+    feature1 = Feature(
+        name="feature1",
+        instance_cardinality=Cardinality(intervals=[]),
+        group_type_cardinality=Cardinality(intervals=[]),
+        group_instance_cardinality=Cardinality(intervals=[]),
+        parents=[],
+        children=[],
+    )
+
+    with pytest.raises(ValueError, match="Feature feature3 not found"):
+        json_import.require_feature("feature3", [feature1])


### PR DESCRIPTION
The changes to the json sandwich test files are actually quite minimal, which can be seen by turning off whitespace in the github review UI.

The json export has been completely rewritten. It now serializes parent/children relationships and references from constraints. The corresponding parts in the json import have been adjusted accordingly.