### PR TITLE
Fix UVL import did not pass type checks

### DIFF
--- a/cfmtoolbox/plugins/uvl_import.py
+++ b/cfmtoolbox/plugins/uvl_import.py
@@ -1,12 +1,11 @@
 from enum import Enum
 from typing import Dict
 
-from antlr4 import CommonTokenStream, InputStream
-from antlr4.error.ErrorListener import ErrorListener
-from colorama import Fore
-from uvl.UVLCustomLexer import UVLCustomLexer
-from uvl.UVLPythonListener import UVLPythonListener
-from uvl.UVLPythonParser import UVLPythonParser
+from antlr4 import CommonTokenStream, InputStream  # type: ignore
+from antlr4.error.ErrorListener import ErrorListener  # type: ignore
+from uvl.UVLCustomLexer import UVLCustomLexer  # type: ignore
+from uvl.UVLPythonListener import UVLPythonListener  # type: ignore
+from uvl.UVLPythonParser import UVLPythonParser  # type: ignore
 
 from cfmtoolbox import CFM, app
 from cfmtoolbox.models import Cardinality, Constraint, Feature, Interval
@@ -151,7 +150,7 @@ class CustomListener(UVLPythonListener):
                 if not self.warning_printed.get("groups", False):
                     self.warning_printed["groups"] = True
                     print(
-                        f"{Fore.YELLOW}Some information will be lost, due to the fact that CFM does not support multiple groups in a feature{Fore.RESET}"
+                        "Some information will be lost, due to the fact that CFM does not support multiple groups in a feature"
                     )
 
                 parent_feature = Feature(
@@ -163,7 +162,7 @@ class CustomListener(UVLPythonListener):
                     [],
                 )
                 min_cardinality = 0
-                max_cardinality = 0
+                max_cardinality: int | None = 0
                 for index, group in enumerate(self.groups[-new_groups:]):
                     cardinality = group[0]
                     features = group[1]
@@ -343,7 +342,7 @@ class CustomListener(UVLPythonListener):
                 )
             )
         else:
-            print(f"{Fore.YELLOW} ERROR, operation {op} not supported yet{Fore.RESET}")
+            print(f"ERROR, operation {op} not supported yet")
 
     def exitEquivalenceConstraint(
         self, ctx: UVLPythonParser.EquivalenceConstraintContext
@@ -366,7 +365,7 @@ class CustomListener(UVLPythonListener):
     def exitAttributes(self, ctx: UVLPythonParser.AttributesContext):
         if not self.warning_printed.get("attributes", False):
             self.warning_printed["attributes"] = True
-            print(f"{Fore.YELLOW}Text is not supported in CFM{Fore.RESET}")
+            print("Text is not supported in CFM")
 
 
 @app.importer(".uvl")

--- a/tests/plugins/test_uvl_import.py
+++ b/tests/plugins/test_uvl_import.py
@@ -884,7 +884,7 @@ def test_exit_group_spec_three_features_two_used(listener):
 
 def test_exit_mandatory_group_one_feature_without_instance_cardinality(listener):
     mock_ctx = Mock()
-    feature: Feature = Feature(
+    feature = Feature(
         name="test",
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
@@ -915,7 +915,7 @@ def test_exit_mandatory_group_one_feature_without_instance_cardinality(listener)
 
 def test_exit_mandatory_group_one_feature_with_instance_cardinality(listener):
     mock_ctx = Mock()
-    feature: Feature = Feature(
+    feature = Feature(
         name="test",
         instance_cardinality=Cardinality([Interval(2, 2)]),
         group_type_cardinality=Cardinality([]),
@@ -934,7 +934,7 @@ def test_exit_mandatory_group_one_feature_with_instance_cardinality(listener):
 
 def test_exit_or_group(listener):
     mock_ctx = Mock()
-    feature: Feature = Feature(
+    feature = Feature(
         name="test",
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
@@ -953,7 +953,7 @@ def test_exit_or_group(listener):
 
 def test_exit_alternative_group(listener):
     mock_ctx = Mock()
-    feature: Feature = Feature(
+    feature = Feature(
         name="test",
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
@@ -972,7 +972,7 @@ def test_exit_alternative_group(listener):
 
 def test_exit_optional_group_without_instance_cardinality(listener):
     mock_ctx = Mock()
-    feature: Feature = Feature(
+    feature = Feature(
         name="test",
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
@@ -991,7 +991,7 @@ def test_exit_optional_group_without_instance_cardinality(listener):
 
 def test_exit_optional_group_with_instance_cardinality_lower_changed_to_zero(listener):
     mock_ctx = Mock()
-    feature: Feature = Feature(
+    feature = Feature(
         name="test",
         instance_cardinality=Cardinality([Interval(3, 5)]),
         group_type_cardinality=Cardinality([]),
@@ -1022,7 +1022,7 @@ def test_exit_optional_group_with_instance_cardinality_lower_changed_to_zero(lis
 
 def test_exit_optional_group_with_instance_cardinality_lower_not_changed(listener):
     mock_ctx = Mock()
-    feature: Feature = Feature(
+    feature = Feature(
         name="test",
         instance_cardinality=Cardinality([Interval(0, 5)]),
         group_type_cardinality=Cardinality([]),
@@ -1042,7 +1042,7 @@ def test_exit_optional_group_with_instance_cardinality_lower_not_changed(listene
 def test_exit_cardinality_group_one_value(listener):
     mock_ctx = Mock()
     mock_ctx.getText.return_value = "[1]"
-    feature: Feature = Feature(
+    feature = Feature(
         name="test",
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
@@ -1062,7 +1062,7 @@ def test_exit_cardinality_group_one_value(listener):
 def test_exit_cardinality_group_multiple_values(listener):
     mock_ctx = Mock()
     mock_ctx.getText.return_value = "[2..4]"
-    feature: Feature = Feature(
+    feature = Feature(
         name="test",
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
@@ -1082,7 +1082,7 @@ def test_exit_cardinality_group_multiple_values(listener):
 def test_exit_cardinality_group_multiple_values_including_asterisk(listener):
     mock_ctx = Mock()
     mock_ctx.getText.return_value = "[2..*]"
-    feature: Feature = Feature(
+    feature = Feature(
         name="test",
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),


### PR DESCRIPTION
Running `poetry run mypy .` fails without this PR (mostly because untyped third-party libraries were used). Investigating now why CI did not catch that.