### PR TITLE
Store only the direct parent of a feature

### DIFF
--- a/cfmtoolbox/models.py
+++ b/cfmtoolbox/models.py
@@ -35,7 +35,7 @@ class Feature:
     instance_cardinality: Cardinality
     group_type_cardinality: Cardinality
     group_instance_cardinality: Cardinality
-    parents: list["Feature"]
+    parent: "Feature | None"
     children: list["Feature"]
 
     def __str__(self) -> str:
@@ -43,10 +43,6 @@ class Feature:
 
     def is_required(self) -> bool:
         return self.instance_cardinality.intervals[0].lower != 0
-
-    def add_parent(self, parent: "Feature"):
-        if parent not in self.parents:
-            self.parents.append(parent)
 
     def add_child(self, child: "Feature"):
         if child not in self.children:

--- a/cfmtoolbox/plugins/debugging.py
+++ b/cfmtoolbox/plugins/debugging.py
@@ -14,7 +14,7 @@ def stringify_cfm(cfm: CFM | None) -> str:
 
     for feature in cfm.features:
         formatted_cfm += f"{feature}: instance [{feature.instance_cardinality}], group type [{feature.group_type_cardinality}], group instance [{feature.group_instance_cardinality}]\n"
-        formatted_cfm += stringify_list("parents", feature.parents)
+        formatted_cfm += f"- parent: {feature.parent}\n"
         formatted_cfm += stringify_list("children", feature.children) + "\n"
 
     formatted_cfm += stringify_list("Require constraints", cfm.require_constraints)

--- a/cfmtoolbox/plugins/featureide_import.py
+++ b/cfmtoolbox/plugins/featureide_import.py
@@ -73,7 +73,7 @@ def parse_feature(feature: Element) -> Feature:
         instance_cardinality=feature_cardinality,
         group_instance_cardinality=group_cardinality,
         group_type_cardinality=group_cardinality,
-        parents=[],
+        parent=None,
         children=[],
     )
 
@@ -84,7 +84,7 @@ def traverse_xml(element: Element | None, cfm: CFM) -> list[Feature]:
 
         for child in element:
             feature = parse_feature(child)
-            feature.add_parent(parent)
+            feature.parent = parent
             parent.add_child(feature)
             cfm.add_feature(feature)
             traverse_xml(child, cfm)

--- a/cfmtoolbox/plugins/json_import.py
+++ b/cfmtoolbox/plugins/json_import.py
@@ -38,7 +38,7 @@ def parse_cfm(serialized_cfm: JSON) -> CFM:
 
 
 def parse_root(serialized_root: JSON) -> list[Feature]:
-    root = parse_feature(serialized_root, parents=[])
+    root = parse_feature(serialized_root, parent=None)
 
     features = [root]
 
@@ -48,7 +48,7 @@ def parse_root(serialized_root: JSON) -> list[Feature]:
     return features
 
 
-def parse_feature(serialized_feature: JSON, /, parents: list[Feature]) -> Feature:
+def parse_feature(serialized_feature: JSON, /, parent: Feature | None) -> Feature:
     if not isinstance(serialized_feature, dict):
         raise TypeError(f"Feature must be an object: {serialized_feature}")
 
@@ -77,12 +77,12 @@ def parse_feature(serialized_feature: JSON, /, parents: list[Feature]) -> Featur
         instance_cardinality=instance_cardinality,
         group_type_cardinality=group_type_cardinality,
         group_instance_cardinality=group_instance_cardinality,
-        parents=parents,
+        parent=parent,
         children=[],
     )
 
     feature.children = [
-        parse_feature(serialized_child, parents=[feature])
+        parse_feature(serialized_child, parent=feature)
         for serialized_child in serialized_feature["children"]
     ]
 

--- a/cfmtoolbox/plugins/uvl_import.py
+++ b/cfmtoolbox/plugins/uvl_import.py
@@ -136,7 +136,7 @@ class CustomListener(UVLPythonListener):
                 instance_cardinality,
                 group_type_cardinality,
                 group_instance_cardinality,
-                [],
+                None,
                 [],
             )
             self.feature_map[name] = feature
@@ -158,7 +158,7 @@ class CustomListener(UVLPythonListener):
                     instance_cardinality,
                     Cardinality([Interval(0, new_groups)]),
                     Cardinality([]),
-                    [],
+                    None,
                     [],
                 )
                 min_cardinality = 0
@@ -200,7 +200,7 @@ class CustomListener(UVLPythonListener):
                         Cardinality([Interval(0, None)]),
                         group_type_cardinality,
                         group_instance_cardinality,
-                        [],
+                        None,
                         features,
                     )
                     parent_feature.children.append(feature)
@@ -214,7 +214,7 @@ class CustomListener(UVLPythonListener):
                         )
                     )
                     for child in features:
-                        child.parents = [feature]
+                        child.parent = feature
                         if len(child.instance_cardinality.intervals) > 0:
                             min_cardinality += child.instance_cardinality.intervals[
                                 0
@@ -225,7 +225,7 @@ class CustomListener(UVLPythonListener):
                             else:
                                 max_cardinality = None
                 for child in parent_feature.children:
-                    child.parents = [parent_feature]
+                    child.parent = parent_feature
                 parent_feature.group_instance_cardinality = Cardinality(
                     [
                         Interval(
@@ -275,11 +275,11 @@ class CustomListener(UVLPythonListener):
                     instance_cardinality,
                     group_type_cardinality,
                     group_instance_cardinality,
-                    [],
+                    None,
                     features,
                 )
                 for child in feature.children:
-                    child.parents = [feature]
+                    child.parent = feature
                 self.feature_map[name] = feature
                 self.features.append(feature)
                 self.cfm.features.append(feature)

--- a/tests/plugins/test_big_m.py
+++ b/tests/plugins/test_big_m.py
@@ -40,14 +40,14 @@ def test_replace_infinite_upper_bound_with_global_upper_bound():
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(1, 3)]),
         Cardinality([Interval(1, None)]),
-        [],
+        None,
         [
             Feature(
                 "Tomato",
                 Cardinality([Interval(0, None)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             Feature(
@@ -55,7 +55,7 @@ def test_replace_infinite_upper_bound_with_global_upper_bound():
                 Cardinality([Interval(0, None)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             Feature(
@@ -63,7 +63,7 @@ def test_replace_infinite_upper_bound_with_global_upper_bound():
                 Cardinality([Interval(0, 3)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
         ],

--- a/tests/plugins/test_debugging.py
+++ b/tests/plugins/test_debugging.py
@@ -19,47 +19,47 @@ def test_debug(capsys):
     expected_output = dedent("""\
     CFM:
     Sandwich: instance [1..1], group type [1..3], group instance [1..3]
-    - parents: 
+    - parent: None
     - children: Bread, CheeseMix, Veggies
 
     Bread: instance [1..1], group type [1..1], group instance [1..1]
-    - parents: Sandwich
+    - parent: Sandwich
     - children: Sourdough, Wheat
 
     Sourdough: instance [0..1], group type [], group instance []
-    - parents: Bread
+    - parent: Bread
     - children: 
 
     Wheat: instance [0..1], group type [], group instance []
-    - parents: Bread
+    - parent: Bread
     - children: 
 
     CheeseMix: instance [0..1], group type [1..3], group instance [1..3]
-    - parents: Sandwich
+    - parent: Sandwich
     - children: Cheddar, Swiss, Gouda
 
     Cheddar: instance [0..1], group type [], group instance []
-    - parents: CheeseMix
+    - parent: CheeseMix
     - children: 
 
     Swiss: instance [0..1], group type [], group instance []
-    - parents: CheeseMix
+    - parent: CheeseMix
     - children: 
 
     Gouda: instance [0..1], group type [], group instance []
-    - parents: CheeseMix
+    - parent: CheeseMix
     - children: 
 
     Veggies: instance [0..1], group type [1..2], group instance [1..2]
-    - parents: Sandwich
+    - parent: Sandwich
     - children: Lettuce, Tomato
 
     Lettuce: instance [0..1], group type [], group instance []
-    - parents: Veggies
+    - parent: Veggies
     - children: 
 
     Tomato: instance [0..1], group type [], group instance []
-    - parents: Veggies
+    - parent: Veggies
     - children: 
 
     - Require constraints: Sourdough => Cheddar, Tomato => Gouda, Swiss => Lettuce
@@ -91,7 +91,7 @@ def test_stringify_cfm():
     cfm_str = dedent("""\
     CFM:
     Sandwich: instance [1..0], group type [1..3], group instance [2..2]
-    - parents: 
+    - parent: None
     - children: 
 
     - Require constraints: Sandwich => Sandwich
@@ -103,7 +103,7 @@ def test_stringify_cfm():
         Cardinality([Interval(1, 0)]),
         Cardinality([Interval(1, 3)]),
         Cardinality([Interval(2, 2)]),
-        [],
+        None,
         [],
     )
 

--- a/tests/plugins/test_featureide_import.py
+++ b/tests/plugins/test_featureide_import.py
@@ -135,7 +135,7 @@ def test_parse_feature():
     assert feature.name == "Sandwich"
     assert feature.instance_cardinality == Cardinality([Interval(0, 1)])
     assert feature.group_instance_cardinality == Cardinality([])
-    assert feature.parents == []
+    assert feature.parent is None
     assert feature.children == []
 
 
@@ -146,7 +146,7 @@ def test_parse_feature_can_parse_with_mandatory_feature():
     assert feature.name == "Sandwich"
     assert feature.instance_cardinality == Cardinality([Interval(1, 1)])
     assert feature.group_instance_cardinality == Cardinality([])
-    assert feature.parents == []
+    assert feature.parent is None
     assert feature.children == []
 
 
@@ -157,7 +157,7 @@ def test_parse_feature_can_parse_with_mandatory_is_false():
     assert feature.name == "Sandwich"
     assert feature.instance_cardinality == Cardinality([Interval(0, 1)])
     assert feature.group_instance_cardinality == Cardinality([])
-    assert feature.parents == []
+    assert feature.parent is None
     assert feature.children == []
 
 
@@ -168,7 +168,7 @@ def test_parse_feature_can_parse_with_mandatory_is_none():
     assert feature.name == "Sandwich"
     assert feature.instance_cardinality == Cardinality([Interval(0, 1)])
     assert feature.group_instance_cardinality == Cardinality([])
-    assert feature.parents == []
+    assert feature.parent is None
     assert feature.children == []
 
 
@@ -187,7 +187,7 @@ def test_traverse_xml():
 
     assert len(feature_list) == 11
     assert feature_list[0].name == "Sandwich"
-    assert feature_list[0].parents == []
+    assert feature_list[0].parent is None
     assert feature_list[0].children == [
         feature_list[1],
         feature_list[4],
@@ -195,19 +195,19 @@ def test_traverse_xml():
     ]
 
     assert feature_list[1].name == "Bread"
-    assert feature_list[1].parents == [feature_list[0]]
+    assert feature_list[1].parent == feature_list[0]
     assert feature_list[1].children == [feature_list[2], feature_list[3]]
 
     assert feature_list[2].name == "Sourdough"
-    assert feature_list[2].parents == [feature_list[1]]
+    assert feature_list[2].parent == feature_list[1]
     assert feature_list[2].children == []
 
     assert feature_list[3].name == "Wheat"
-    assert feature_list[3].parents == [feature_list[1]]
+    assert feature_list[3].parent == feature_list[1]
     assert feature_list[3].children == []
 
     assert feature_list[4].name == "CheeseMix"
-    assert feature_list[4].parents == [feature_list[0]]
+    assert feature_list[4].parent == feature_list[0]
     assert feature_list[4].children == [
         feature_list[5],
         feature_list[6],
@@ -215,27 +215,27 @@ def test_traverse_xml():
     ]
 
     assert feature_list[5].name == "Cheddar"
-    assert feature_list[5].parents == [feature_list[4]]
+    assert feature_list[5].parent == feature_list[4]
     assert feature_list[5].children == []
 
     assert feature_list[6].name == "Swiss"
-    assert feature_list[6].parents == [feature_list[4]]
+    assert feature_list[6].parent == feature_list[4]
     assert feature_list[6].children == []
 
     assert feature_list[7].name == "Gouda"
-    assert feature_list[7].parents == [feature_list[4]]
+    assert feature_list[7].parent == feature_list[4]
     assert feature_list[7].children == []
 
     assert feature_list[8].name == "Veggies"
-    assert feature_list[8].parents == [feature_list[0]]
+    assert feature_list[8].parent == feature_list[0]
     assert feature_list[8].children == [feature_list[9], feature_list[10]]
 
     assert feature_list[9].name == "Lettuce"
-    assert feature_list[9].parents == [feature_list[8]]
+    assert feature_list[9].parent == feature_list[8]
     assert feature_list[9].children == []
 
     assert feature_list[10].name == "Tomato"
-    assert feature_list[10].parents == [feature_list[8]]
+    assert feature_list[10].parent == feature_list[8]
     assert feature_list[10].children == []
 
 
@@ -249,7 +249,7 @@ def test_parse_formula_value_and_feature():
     root.text = "Bread"
 
     feature = Feature(
-        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
 
     value, formula = parse_formula_value_and_feature(root, CFM([feature], [], []))
@@ -268,7 +268,7 @@ def test_parse_formula_value_and_feature_can_parse_more_complex_formula_with_eve
     SubElement(element, "var").text = "Bread"
 
     feature = Feature(
-        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
 
     formula = parse_formula_value_and_feature(root, CFM([feature], [], []))
@@ -281,7 +281,7 @@ def test_parse_formula_value_and_feature_can_parse_more_complex_formula_with_odd
     SubElement(SubElement(subelement, "not"), "var").text = "Bread"
 
     feature = Feature(
-        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
 
     formula = parse_formula_value_and_feature(root, CFM([feature], [], []))
@@ -337,7 +337,7 @@ def test_parse_constraint_can_parse_constraint_with_one_require_rule():
     SubElement(imp, "var").text = "Bread"
     SubElement(imp, "var").text = "Bread"
     feature = Feature(
-        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
     cfm = CFM([feature], [], [])
 
@@ -364,7 +364,7 @@ def test_parse_constraint_can_parse_constraint_with_one_exclude_rule():
     SubElement(negation, "var").text = "Bread"
     SubElement(imp, "var").text = "Bread"
     feature = Feature(
-        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
     cfm = CFM([feature], [], [])
 
@@ -393,11 +393,11 @@ def test_parse_constraint_can_parse_constraint_with_both_formulas_negative():
     SubElement(second_negation, "var").text = "Cheese"
 
     bread_feature = Feature(
-        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
 
     cheese_feature = Feature(
-        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
 
     constraint = Constraint(

--- a/tests/plugins/test_json_export.py
+++ b/tests/plugins/test_json_export.py
@@ -16,7 +16,7 @@ def test_export_json():
         instance_cardinality=Cardinality(intervals=[]),
         group_type_cardinality=Cardinality(intervals=[]),
         group_instance_cardinality=Cardinality(intervals=[]),
-        parents=[],
+        parent=None,
         children=[],
     )
 
@@ -48,7 +48,7 @@ def test_serialize_feature_can_serialize_standalone_features():
         instance_cardinality=Cardinality(intervals=[]),
         group_type_cardinality=Cardinality(intervals=[]),
         group_instance_cardinality=Cardinality(intervals=[]),
-        parents=[],
+        parent=None,
         children=[],
     )
 
@@ -68,7 +68,7 @@ def test_serialize_feature_can_serialize_children():
         instance_cardinality=Cardinality(intervals=[]),
         group_type_cardinality=Cardinality(intervals=[]),
         group_instance_cardinality=Cardinality(intervals=[]),
-        parents=[],
+        parent=None,
         children=[],
     )
 
@@ -77,7 +77,7 @@ def test_serialize_feature_can_serialize_children():
         instance_cardinality=Cardinality(intervals=[]),
         group_type_cardinality=Cardinality(intervals=[]),
         group_instance_cardinality=Cardinality(intervals=[]),
-        parents=[sandwich],
+        parent=sandwich,
         children=[],
     )
 
@@ -144,7 +144,7 @@ def test_serialize_constraint():
         instance_cardinality=Cardinality(intervals=[]),
         group_type_cardinality=Cardinality(intervals=[]),
         group_instance_cardinality=Cardinality(intervals=[]),
-        parents=[],
+        parent=None,
         children=[],
     )
 
@@ -153,7 +153,7 @@ def test_serialize_constraint():
         instance_cardinality=Cardinality(intervals=[]),
         group_type_cardinality=Cardinality(intervals=[]),
         group_instance_cardinality=Cardinality(intervals=[]),
-        parents=[],
+        parent=None,
         children=[],
     )
 

--- a/tests/plugins/test_json_import.py
+++ b/tests/plugins/test_json_import.py
@@ -125,14 +125,12 @@ def test_parse_root_returns_all_features_in_the_tree():
             "instance_cardinality": {"intervals": []},
             "group_type_cardinality": {"intervals": []},
             "group_instance_cardinality": {"intervals": []},
-            "parents": [],
             "children": [
                 {
                     "name": "meat",
                     "instance_cardinality": {"intervals": []},
                     "group_type_cardinality": {"intervals": []},
                     "group_instance_cardinality": {"intervals": []},
-                    "parents": [],
                     "children": [],
                 },
                 {
@@ -140,14 +138,12 @@ def test_parse_root_returns_all_features_in_the_tree():
                     "instance_cardinality": {"intervals": []},
                     "group_type_cardinality": {"intervals": []},
                     "group_instance_cardinality": {"intervals": []},
-                    "parents": [],
                     "children": [
                         {
                             "name": "sourdough",
                             "instance_cardinality": {"intervals": []},
                             "group_type_cardinality": {"intervals": []},
                             "group_instance_cardinality": {"intervals": []},
-                            "parents": [],
                             "children": [],
                         },
                         {
@@ -155,7 +151,6 @@ def test_parse_root_returns_all_features_in_the_tree():
                             "instance_cardinality": {"intervals": []},
                             "group_type_cardinality": {"intervals": []},
                             "group_instance_cardinality": {"intervals": []},
-                            "parents": [],
                             "children": [],
                         },
                     ],
@@ -187,7 +182,7 @@ def test_parse_root_returns_all_features_in_the_tree():
 )
 def test_parse_feature_requires_feature_to_be_an_object(feature, expectation):
     with expectation:
-        json_import.parse_feature(feature, [])
+        json_import.parse_feature(feature, parent=None)
 
 
 @pytest.mark.parametrize(
@@ -205,7 +200,7 @@ def test_parse_feature_requires_feature_to_be_an_object(feature, expectation):
 )
 def test_parse_feature_requires_name_to_be_a_string(name, expectation):
     with expectation:
-        json_import.parse_feature({"name": name}, parents=[])
+        json_import.parse_feature({"name": name}, parent=None)
 
 
 @pytest.mark.parametrize(
@@ -223,9 +218,7 @@ def test_parse_feature_requires_name_to_be_a_string(name, expectation):
 )
 def test_parse_feature_requires_children_to_be_a_list(children, expectation):
     with expectation:
-        json_import.parse_feature(
-            {"name": "name", "parents": [], "children": children}, []
-        )
+        json_import.parse_feature({"name": "name", "children": children}, None)
 
 
 def test_parse_feature_parses_features_and_adds_relatives():
@@ -245,14 +238,14 @@ def test_parse_feature_parses_features_and_adds_relatives():
                 }
             ],
         },
-        [],
+        parent=None,
     )
 
     assert feature.name == "sandwich"
     assert feature.instance_cardinality == Cardinality(intervals=[])
     assert feature.group_type_cardinality == Cardinality(intervals=[])
     assert feature.group_instance_cardinality == Cardinality(intervals=[])
-    assert len(feature.parents) == 0
+    assert feature.parent is None
     assert len(feature.children) == 1
 
     child = feature.children[0]
@@ -260,7 +253,7 @@ def test_parse_feature_parses_features_and_adds_relatives():
     assert child.instance_cardinality == Cardinality(intervals=[])
     assert child.group_type_cardinality == Cardinality(intervals=[])
     assert child.group_instance_cardinality == Cardinality(intervals=[])
-    assert child.parents == [feature]
+    assert child.parent == feature
     assert len(child.children) == 0
 
 
@@ -590,7 +583,7 @@ def test_parse_constraint_returns_constraint_with_inserted_features():
             instance_cardinality=Cardinality(intervals=[]),
             group_type_cardinality=Cardinality(intervals=[]),
             group_instance_cardinality=Cardinality(intervals=[]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -598,7 +591,7 @@ def test_parse_constraint_returns_constraint_with_inserted_features():
             instance_cardinality=Cardinality(intervals=[]),
             group_type_cardinality=Cardinality(intervals=[]),
             group_instance_cardinality=Cardinality(intervals=[]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -630,7 +623,7 @@ def test_parse_constraint_requires_named_features_to_exist():
             instance_cardinality=Cardinality(intervals=[]),
             group_type_cardinality=Cardinality(intervals=[]),
             group_instance_cardinality=Cardinality(intervals=[]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -654,7 +647,7 @@ def test_require_feature_returns_first_match():
         instance_cardinality=Cardinality(intervals=[]),
         group_type_cardinality=Cardinality(intervals=[]),
         group_instance_cardinality=Cardinality(intervals=[]),
-        parents=[],
+        parent=None,
         children=[],
     )
 
@@ -663,7 +656,7 @@ def test_require_feature_returns_first_match():
         instance_cardinality=Cardinality(intervals=[]),
         group_type_cardinality=Cardinality(intervals=[]),
         group_instance_cardinality=Cardinality(intervals=[]),
-        parents=[],
+        parent=None,
         children=[],
     )
 
@@ -677,7 +670,7 @@ def test_require_feature_raises_error_when_there_is_no_match():
         instance_cardinality=Cardinality(intervals=[]),
         group_type_cardinality=Cardinality(intervals=[]),
         group_instance_cardinality=Cardinality(intervals=[]),
-        parents=[],
+        parent=None,
         children=[],
     )
 

--- a/tests/plugins/test_random_sampling.py
+++ b/tests/plugins/test_random_sampling.py
@@ -78,7 +78,7 @@ def test_get_sorted_sample(random_sampler: RandomSampler):
             Cardinality([Interval(0, 1)]),
             Cardinality([]),
             Cardinality([]),
-            [],
+            None,
             [],
         ),
         Feature(
@@ -86,7 +86,7 @@ def test_get_sorted_sample(random_sampler: RandomSampler):
             Cardinality([Interval(0, 2)]),
             Cardinality([]),
             Cardinality([]),
-            [],
+            None,
             [],
         ),
         Feature(
@@ -94,7 +94,7 @@ def test_get_sorted_sample(random_sampler: RandomSampler):
             Cardinality([Interval(0, 3)]),
             Cardinality([]),
             Cardinality([]),
-            [],
+            None,
             [],
         ),
     ]
@@ -113,14 +113,14 @@ def test_get_required_children(random_sampler: RandomSampler):
         Cardinality([]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [
             Feature(
                 "Milk",
                 Cardinality([Interval(1, 1)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             )
         ],
@@ -131,14 +131,14 @@ def test_get_required_children(random_sampler: RandomSampler):
         Cardinality([]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [
             Feature(
                 "Milk",
                 Cardinality([Interval(2, 2)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             Feature(
@@ -146,14 +146,14 @@ def test_get_required_children(random_sampler: RandomSampler):
                 Cardinality([Interval(1, 4)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
         ],
     )
     assert len(random_sampler.get_required_children(feature)) == 2
     feature = Feature(
-        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
     assert len(random_sampler.get_required_children(feature)) == 0
     feature = Feature(
@@ -161,14 +161,14 @@ def test_get_required_children(random_sampler: RandomSampler):
         Cardinality([]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [
             Feature(
                 "Milk",
                 Cardinality([Interval(0, 5)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             )
         ],
@@ -182,14 +182,14 @@ def test_get_optional_children(random_sampler: RandomSampler):
         Cardinality([]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [
             Feature(
                 "Milk",
                 Cardinality([Interval(0, 1)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             Feature(
@@ -197,7 +197,7 @@ def test_get_optional_children(random_sampler: RandomSampler):
                 Cardinality([Interval(1, 4)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
         ],
@@ -208,14 +208,14 @@ def test_get_optional_children(random_sampler: RandomSampler):
         Cardinality([]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [
             Feature(
                 "Milk",
                 Cardinality([Interval(0, 2)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             Feature(
@@ -223,14 +223,14 @@ def test_get_optional_children(random_sampler: RandomSampler):
                 Cardinality([Interval(0, 4)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
         ],
     )
     assert len(random_sampler.get_optional_children(feature)) == 2
     feature = Feature(
-        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
     assert len(random_sampler.get_optional_children(feature)) == 0
     feature = Feature(
@@ -238,14 +238,14 @@ def test_get_optional_children(random_sampler: RandomSampler):
         Cardinality([]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [
             Feature(
                 "Milk",
                 Cardinality([Interval(1, 5)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             )
         ],
@@ -256,14 +256,14 @@ def test_get_optional_children(random_sampler: RandomSampler):
         Cardinality([]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [
             Feature(
                 "Milk",
                 Cardinality([Interval(3, 5)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             Feature(
@@ -271,7 +271,7 @@ def test_get_optional_children(random_sampler: RandomSampler):
                 Cardinality([Interval(2, 5)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
         ],
@@ -287,14 +287,14 @@ def test_generate_random_children_with_random_cardinality(
         Cardinality([]),
         Cardinality([Interval(1, 3)]),
         Cardinality([Interval(3, 3)]),
-        [],
+        None,
         [
             Feature(
                 "Cheddar",
                 Cardinality([Interval(0, 1)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             Feature(
@@ -302,7 +302,7 @@ def test_generate_random_children_with_random_cardinality(
                 Cardinality([Interval(0, 2)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             Feature(
@@ -310,7 +310,7 @@ def test_generate_random_children_with_random_cardinality(
                 Cardinality([Interval(0, 3)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
         ],

--- a/tests/plugins/test_uvl_export.py
+++ b/tests/plugins/test_uvl_export.py
@@ -29,7 +29,7 @@ def test_serialize_group_cardinality_can_export_to_alternative():
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(1, 1)]),
-        [],
+        None,
         [],
     )
 
@@ -38,7 +38,7 @@ def test_serialize_group_cardinality_can_export_to_alternative():
         Cardinality([Interval(0, 1)]),
         Cardinality([]),
         Cardinality([]),
-        [sandwich],
+        sandwich,
         [],
     )
 
@@ -53,7 +53,7 @@ def test_serialize_group_cardinality_can_export_to_or():
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(1, 2)]),
         Cardinality([Interval(1, 3)]),
-        [],
+        None,
         [],
     )
 
@@ -62,7 +62,7 @@ def test_serialize_group_cardinality_can_export_to_or():
         Cardinality([Interval(0, 2)]),
         Cardinality([]),
         Cardinality([]),
-        [sandwich],
+        sandwich,
         [],
     )
 
@@ -71,7 +71,7 @@ def test_serialize_group_cardinality_can_export_to_or():
         Cardinality([Interval(0, 2)]),
         Cardinality([]),
         Cardinality([]),
-        [sandwich],
+        sandwich,
         [],
     )
 
@@ -87,7 +87,7 @@ def test_serialize_group_cardinality_can_export_to_one_numbered_cardinality():
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(2, 2)]),
         Cardinality([Interval(2, 2)]),
-        [],
+        None,
         [],
     )
 
@@ -96,7 +96,7 @@ def test_serialize_group_cardinality_can_export_to_one_numbered_cardinality():
         Cardinality([Interval(2, 2)]),
         Cardinality([]),
         Cardinality([]),
-        [sandwich],
+        sandwich,
         [],
     )
 
@@ -111,7 +111,7 @@ def test_serialize_group_cardinality_can_export_to_cardinality():
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(0, 3)]),
         Cardinality([Interval(1, 3)]),
-        [],
+        None,
         [],
     )
 
@@ -120,7 +120,7 @@ def test_serialize_group_cardinality_can_export_to_cardinality():
         Cardinality([Interval(0, 3)]),
         Cardinality([]),
         Cardinality([]),
-        [sandwich],
+        sandwich,
         [],
     )
 
@@ -135,7 +135,7 @@ def test_serialize_group_cardinality_can_export_to_nothing():
         Cardinality([Interval(1, 1)]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [],
     )
 
@@ -160,7 +160,7 @@ def test_serialize_root_feature():
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(0, 2)]),
         Cardinality([Interval(0, 2)]),
-        [],
+        None,
         [],
     )
 
@@ -169,7 +169,7 @@ def test_serialize_root_feature():
         Cardinality([Interval(0, 2)]),
         Cardinality([]),
         Cardinality([]),
-        [root],
+        root,
         [],
     )
 
@@ -184,7 +184,7 @@ def test_serialize_root_feature_raises_type_error_on_group_instance_compounded_c
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(0, 2)]),
         Cardinality([Interval(0, 2), Interval(2, 2)]),
-        [],
+        None,
         [],
     )
     with pytest.raises(TypeError, match="UVL cannot handle compounded cardinalities"):
@@ -197,7 +197,7 @@ def test_serialize_root_feature_raises_type_error_on_group_type_compounded_cardi
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(0, 2), Interval(2, 2)]),
         Cardinality([Interval(0, 2)]),
-        [],
+        None,
         [],
     )
     with pytest.raises(TypeError, match="UVL cannot handle compounded cardinalities"):
@@ -210,7 +210,7 @@ def test_serialize_features_raises_type_error_on_compounded_cardinality():
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(0, 2)]),
         Cardinality([Interval(0, 2), Interval(2, 2)]),
-        [],
+        None,
         [],
     )
     with pytest.raises(TypeError, match="UVL cannot handle compounded cardinalities"):
@@ -223,7 +223,7 @@ def test_serialize_features_can_export_single_child_feature():
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(0, 2)]),
         Cardinality([Interval(0, 2)]),
-        [],
+        None,
         [],
     )
 
@@ -232,7 +232,7 @@ def test_serialize_features_can_export_single_child_feature():
         Cardinality([Interval(0, 2)]),
         Cardinality([]),
         Cardinality([]),
-        [sandwich],
+        sandwich,
         [],
     )
 
@@ -252,7 +252,7 @@ def test_serialize_features():
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(0, 2)]),
         Cardinality([Interval(4, 7)]),
-        [],
+        None,
         [],
     )
 
@@ -261,7 +261,7 @@ def test_serialize_features():
         Cardinality([Interval(2, 2)]),
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(0, 1)]),
-        [sandwich],
+        sandwich,
         [],
     )
 
@@ -270,7 +270,7 @@ def test_serialize_features():
         Cardinality([Interval(0, 1)]),
         Cardinality([]),
         Cardinality([]),
-        [bread],
+        bread,
         [],
     )
 
@@ -279,7 +279,7 @@ def test_serialize_features():
         Cardinality([Interval(0, 1)]),
         Cardinality([]),
         Cardinality([]),
-        [bread],
+        bread,
         [],
     )
 
@@ -288,7 +288,7 @@ def test_serialize_features():
         Cardinality([Interval(2, 4)]),
         Cardinality([Interval(0, 3)]),
         Cardinality([Interval(3, 3)]),
-        [sandwich],
+        sandwich,
         [],
     )
 
@@ -297,7 +297,7 @@ def test_serialize_features():
         Cardinality([Interval(0, 1)]),
         Cardinality([]),
         Cardinality([]),
-        [cheeseMix],
+        cheeseMix,
         [],
     )
 
@@ -306,7 +306,7 @@ def test_serialize_features():
         Cardinality([Interval(0, 2)]),
         Cardinality([]),
         Cardinality([]),
-        [cheeseMix],
+        cheeseMix,
         [],
     )
 
@@ -315,7 +315,7 @@ def test_serialize_features():
         Cardinality([Interval(0, 3)]),
         Cardinality([]),
         Cardinality([]),
-        [cheeseMix],
+        cheeseMix,
         [],
     )
 
@@ -324,7 +324,7 @@ def test_serialize_features():
         Cardinality([Interval(0, 1)]),
         Cardinality([Interval(1, 2)]),
         Cardinality([Interval(1, None)]),
-        [sandwich],
+        sandwich,
         [],
     )
 
@@ -333,7 +333,7 @@ def test_serialize_features():
         Cardinality([Interval(0, None)]),
         Cardinality([]),
         Cardinality([]),
-        [veggies],
+        veggies,
         [],
     )
 
@@ -342,7 +342,7 @@ def test_serialize_features():
         Cardinality([Interval(0, None)]),
         Cardinality([]),
         Cardinality([]),
-        [veggies],
+        veggies,
         [],
     )
 
@@ -384,7 +384,7 @@ def test_serialize_constraint(constraint: Cardinality, expectation: str):
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(0, 2)]),
         Cardinality([Interval(4, 7)]),
-        [],
+        None,
         [],
     )
 
@@ -405,7 +405,7 @@ def test_serialize_constraints(is_required: bool, expectation: str):
         Cardinality([Interval(1, 1)]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [],
     )
 
@@ -416,7 +416,7 @@ def test_serialize_constraints(is_required: bool, expectation: str):
         Cardinality([Interval(1, 2)]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [],
     )
 
@@ -435,7 +435,7 @@ def test_serialize_constraints_raises_type_error_on_compounded_cardinality_on_fi
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(0, 2)]),
         Cardinality([Interval(0, 2)]),
-        [],
+        None,
         [],
     )
 
@@ -460,7 +460,7 @@ def test_serialize_constraints_raises_type_error_on_compounded_cardinality_on_se
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(0, 2)]),
         Cardinality([Interval(0, 2)]),
-        [],
+        None,
         [],
     )
 
@@ -485,7 +485,7 @@ def test_serialize_all_constraints():
         Cardinality([Interval(1, 1)]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [],
     )
 
@@ -496,7 +496,7 @@ def test_serialize_all_constraints():
         Cardinality([Interval(1, 2)]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [],
     )
 

--- a/tests/plugins/test_uvl_import.py
+++ b/tests/plugins/test_uvl_import.py
@@ -57,7 +57,7 @@ def test_exit_feature_lowest_level(
     assert len(listener.features) == 1
     assert listener.features[0].name == "test"
     assert listener.features[0].children == []
-    assert listener.features[0].parents == []
+    assert listener.features[0].parent is None
     assert listener.features[0].instance_cardinality == Cardinality([Interval(0, None)])
     assert listener.features[0].group_type_cardinality == Cardinality([])
     assert listener.features[0].group_instance_cardinality == Cardinality([])
@@ -78,7 +78,7 @@ def test_exit_feature_with_instance_cardinality(listener):
     assert len(listener.features) == 1
     assert listener.features[0].name == "test"
     assert listener.features[0].children == []
-    assert listener.features[0].parents == []
+    assert listener.features[0].parent is None
     assert listener.features[0].instance_cardinality == Cardinality([Interval(1, 1)])
     assert listener.features[0].group_type_cardinality == Cardinality([])
     assert listener.features[0].group_instance_cardinality == Cardinality([])
@@ -98,7 +98,7 @@ def test_exit_feature_with_one_mandatory_group(listener):
             instance_cardinality=Cardinality([Interval(1, 1)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -106,7 +106,7 @@ def test_exit_feature_with_one_mandatory_group(listener):
             instance_cardinality=Cardinality([Interval(1, 1)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -122,7 +122,7 @@ def test_exit_feature_with_one_mandatory_group(listener):
     assert len(listener.features) == 1
     assert listener.features[0].name == "test"
     assert listener.features[0].children == features
-    assert listener.features[0].parents == []
+    assert listener.features[0].parent is None
     assert listener.features[0].instance_cardinality == Cardinality([Interval(0, None)])
     assert listener.features[0].group_type_cardinality == Cardinality([Interval(2, 2)])
     assert listener.features[0].group_instance_cardinality == Cardinality(
@@ -146,7 +146,7 @@ def test_exit_feature_with_one_or_group(listener):
             instance_cardinality=Cardinality([Interval(3, 5)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -154,7 +154,7 @@ def test_exit_feature_with_one_or_group(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -170,7 +170,7 @@ def test_exit_feature_with_one_or_group(listener):
     assert len(listener.features) == 1
     assert listener.features[0].name == "test"
     assert listener.features[0].children == features
-    assert listener.features[0].parents == []
+    assert listener.features[0].parent is None
     assert listener.features[0].instance_cardinality == Cardinality([Interval(2, 7)])
     assert listener.features[0].group_type_cardinality == Cardinality([Interval(1, 2)])
     assert listener.features[0].group_instance_cardinality == Cardinality(
@@ -193,7 +193,7 @@ def test_exit_feature_with_one_alternative_group(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -201,7 +201,7 @@ def test_exit_feature_with_one_alternative_group(listener):
             instance_cardinality=Cardinality([Interval(1, 1)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -217,7 +217,7 @@ def test_exit_feature_with_one_alternative_group(listener):
     assert len(listener.features) == 1
     assert listener.features[0].name == "test"
     assert listener.features[0].children == features
-    assert listener.features[0].parents == []
+    assert listener.features[0].parent is None
     assert listener.features[0].instance_cardinality == Cardinality([Interval(0, None)])
     assert listener.features[0].group_type_cardinality == Cardinality([Interval(1, 1)])
     assert listener.features[0].group_instance_cardinality == Cardinality(
@@ -240,7 +240,7 @@ def test_exit_feature_with_one_optional_group(listener):
             instance_cardinality=Cardinality([Interval(0, 1)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -248,7 +248,7 @@ def test_exit_feature_with_one_optional_group(listener):
             instance_cardinality=Cardinality([Interval(0, 1)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -264,7 +264,7 @@ def test_exit_feature_with_one_optional_group(listener):
     assert len(listener.features) == 1
     assert listener.features[0].name == "test"
     assert listener.features[0].children == features
-    assert listener.features[0].parents == []
+    assert listener.features[0].parent is None
     assert listener.features[0].instance_cardinality == Cardinality([Interval(0, None)])
     assert listener.features[0].group_type_cardinality == Cardinality([Interval(0, 2)])
     assert listener.features[0].group_instance_cardinality == Cardinality(
@@ -287,7 +287,7 @@ def test_exit_feature_with_one_cardinality_group(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -295,7 +295,7 @@ def test_exit_feature_with_one_cardinality_group(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -311,7 +311,7 @@ def test_exit_feature_with_one_cardinality_group(listener):
     assert len(listener.features) == 1
     assert listener.features[0].name == "test"
     assert listener.features[0].children == features
-    assert listener.features[0].parents == []
+    assert listener.features[0].parent is None
     assert listener.features[0].instance_cardinality == Cardinality([Interval(0, None)])
     assert listener.features[0].group_type_cardinality == Cardinality([Interval(0, 2)])
     assert listener.features[0].group_instance_cardinality == Cardinality(
@@ -333,7 +333,7 @@ def test_exit_feature_with_two_groups(listener):
             instance_cardinality=Cardinality([Interval(1, 1)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -341,7 +341,7 @@ def test_exit_feature_with_two_groups(listener):
             instance_cardinality=Cardinality([Interval(1, 1)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -351,7 +351,7 @@ def test_exit_feature_with_two_groups(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -359,7 +359,7 @@ def test_exit_feature_with_two_groups(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -386,7 +386,7 @@ def test_exit_feature_with_two_groups(listener):
         instance_cardinality=Cardinality([Interval(0, None)]),
         group_type_cardinality=Cardinality([Interval(2, 2)]),
         group_instance_cardinality=Cardinality([Interval(2, None)]),
-        parents=[mock_parent],
+        parent=mock_parent,
         children=features1,
     )
 
@@ -395,15 +395,15 @@ def test_exit_feature_with_two_groups(listener):
         instance_cardinality=Cardinality([Interval(0, None)]),
         group_type_cardinality=Cardinality([Interval(1, 2)]),
         group_instance_cardinality=Cardinality([Interval(1, None)]),
-        parents=[mock_parent],
+        parent=mock_parent,
         children=features2,
     )
 
     mock_parent.children = [feature1, feature2]
     for child in listener.cfm.require_constraints[0].first_feature.children:
-        child.parents = [mock_parent]
+        child.parent = mock_parent
 
-    assert listener.features[0].parents == []
+    assert listener.features[0].parent is None
     assert listener.features[0].instance_cardinality == Cardinality([Interval(0, None)])
     assert listener.features[0].group_type_cardinality == Cardinality([Interval(0, 2)])
     assert listener.features[0].group_instance_cardinality == Cardinality(
@@ -441,7 +441,7 @@ def test_exit_feature_with_two_groups_and_instance_cardinality(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -449,7 +449,7 @@ def test_exit_feature_with_two_groups_and_instance_cardinality(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -459,7 +459,7 @@ def test_exit_feature_with_two_groups_and_instance_cardinality(listener):
             instance_cardinality=Cardinality([Interval(0, 1)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -467,7 +467,7 @@ def test_exit_feature_with_two_groups_and_instance_cardinality(listener):
             instance_cardinality=Cardinality([Interval(0, 1)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -494,7 +494,7 @@ def test_exit_feature_with_two_groups_and_instance_cardinality(listener):
         instance_cardinality=Cardinality([Interval(0, None)]),
         group_type_cardinality=Cardinality([Interval(1, 1)]),
         group_instance_cardinality=Cardinality([Interval(1, None)]),
-        parents=[mock_parent],
+        parent=mock_parent,
         children=features1,
     )
 
@@ -503,15 +503,15 @@ def test_exit_feature_with_two_groups_and_instance_cardinality(listener):
         instance_cardinality=Cardinality([Interval(0, None)]),
         group_type_cardinality=Cardinality([Interval(0, 2)]),
         group_instance_cardinality=Cardinality([Interval(0, None)]),
-        parents=[mock_parent],
+        parent=mock_parent,
         children=features2,
     )
 
     mock_parent.children = [feature1, feature2]
     for child in listener.cfm.require_constraints[0].first_feature.children:
-        child.parents = [mock_parent]
+        child.parent = mock_parent
 
-    assert listener.features[0].parents == []
+    assert listener.features[0].parent is None
     assert listener.features[0].instance_cardinality == Cardinality([Interval(3, 4)])
     assert listener.features[0].group_type_cardinality == Cardinality([Interval(0, 2)])
     assert listener.features[0].group_instance_cardinality == Cardinality(
@@ -548,7 +548,7 @@ def test_exit_feature_with_two_groups_including_group_cardinality(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -556,7 +556,7 @@ def test_exit_feature_with_two_groups_including_group_cardinality(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -566,7 +566,7 @@ def test_exit_feature_with_two_groups_including_group_cardinality(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -574,7 +574,7 @@ def test_exit_feature_with_two_groups_including_group_cardinality(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -601,7 +601,7 @@ def test_exit_feature_with_two_groups_including_group_cardinality(listener):
         instance_cardinality=Cardinality([Interval(0, None)]),
         group_type_cardinality=Cardinality([Interval(0, 2)]),
         group_instance_cardinality=Cardinality([Interval(3, 4)]),
-        parents=[mock_parent],
+        parent=mock_parent,
         children=features1,
     )
 
@@ -610,15 +610,15 @@ def test_exit_feature_with_two_groups_including_group_cardinality(listener):
         instance_cardinality=Cardinality([Interval(0, None)]),
         group_type_cardinality=Cardinality([Interval(0, 2)]),
         group_instance_cardinality=Cardinality([Interval(1, 2)]),
-        parents=[mock_parent],
+        parent=mock_parent,
         children=features2,
     )
 
     mock_parent.children = [feature1, feature2]
     for child in listener.cfm.require_constraints[0].first_feature.children:
-        child.parents = [mock_parent]
+        child.parent = mock_parent
 
-    assert listener.features[0].parents == []
+    assert listener.features[0].parent is None
     assert listener.features[0].instance_cardinality == Cardinality([Interval(0, None)])
     assert listener.features[0].group_type_cardinality == Cardinality([Interval(0, 2)])
     assert listener.features[0].group_instance_cardinality == Cardinality(
@@ -657,7 +657,7 @@ def test_exit_feature_with_two_groups_including_group_cardinality_with_instances
             instance_cardinality=Cardinality([Interval(3, 5)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -665,7 +665,7 @@ def test_exit_feature_with_two_groups_including_group_cardinality_with_instances
             instance_cardinality=Cardinality([Interval(2, 3)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -675,7 +675,7 @@ def test_exit_feature_with_two_groups_including_group_cardinality_with_instances
             instance_cardinality=Cardinality([Interval(0, None)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -683,7 +683,7 @@ def test_exit_feature_with_two_groups_including_group_cardinality_with_instances
             instance_cardinality=Cardinality([Interval(3, 3)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -710,7 +710,7 @@ def test_exit_feature_with_two_groups_including_group_cardinality_with_instances
         instance_cardinality=Cardinality([Interval(0, None)]),
         group_type_cardinality=Cardinality([Interval(2, 2)]),
         group_instance_cardinality=Cardinality([Interval(3, 4)]),
-        parents=[mock_parent],
+        parent=mock_parent,
         children=features1,
     )
 
@@ -719,15 +719,15 @@ def test_exit_feature_with_two_groups_including_group_cardinality_with_instances
         instance_cardinality=Cardinality([Interval(0, None)]),
         group_type_cardinality=Cardinality([Interval(1, 2)]),
         group_instance_cardinality=Cardinality([Interval(1, 2)]),
-        parents=[mock_parent],
+        parent=mock_parent,
         children=features2,
     )
 
     mock_parent.children = [feature1, feature2]
     for child in listener.cfm.require_constraints[0].first_feature.children:
-        child.parents = [mock_parent]
+        child.parent = mock_parent
 
-    assert listener.features[0].parents == []
+    assert listener.features[0].parent is None
     assert listener.features[0].instance_cardinality == Cardinality([Interval(0, None)])
     assert listener.features[0].group_type_cardinality == Cardinality([Interval(0, 2)])
     assert listener.features[0].group_instance_cardinality == Cardinality(
@@ -764,7 +764,7 @@ def test_exit_features_with_one_group_with_group_cardinality(listener):
             instance_cardinality=Cardinality([Interval(3, 5)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         Feature(
@@ -772,7 +772,7 @@ def test_exit_features_with_one_group_with_group_cardinality(listener):
             instance_cardinality=Cardinality([Interval(2, 3)]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     ]
@@ -787,7 +787,7 @@ def test_exit_features_with_one_group_with_group_cardinality(listener):
 
     assert len(listener.features) == 1
     assert listener.features[0].name == "test"
-    assert listener.features[0].parents == []
+    assert listener.features[0].parent is None
     assert listener.features[0].instance_cardinality == Cardinality([Interval(0, None)])
     assert listener.features[0].group_type_cardinality == Cardinality([Interval(2, 2)])
     assert listener.features[0].group_instance_cardinality == Cardinality(
@@ -806,7 +806,7 @@ def test_exit_group_spec_one_subfeature(listener):
         instance_cardinality=Cardinality([Interval(1, 1)]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.features = [feature]
@@ -826,7 +826,7 @@ def test_exit_group_spec_two_features(listener):
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     feature2 = Feature(
@@ -834,7 +834,7 @@ def test_exit_group_spec_two_features(listener):
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.features = [feature1, feature2]
@@ -854,7 +854,7 @@ def test_exit_group_spec_three_features_two_used(listener):
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     feature2 = Feature(
@@ -862,7 +862,7 @@ def test_exit_group_spec_three_features_two_used(listener):
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     feature3 = Feature(
@@ -870,7 +870,7 @@ def test_exit_group_spec_three_features_two_used(listener):
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.features = [feature1, feature2, feature3]
@@ -889,7 +889,7 @@ def test_exit_mandatory_group_one_feature_without_instance_cardinality(listener)
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.group_specs = [[feature]]
@@ -906,7 +906,7 @@ def test_exit_mandatory_group_one_feature_without_instance_cardinality(listener)
                 instance_cardinality=Cardinality([Interval(1, 1)]),
                 group_type_cardinality=Cardinality([]),
                 group_instance_cardinality=Cardinality([]),
-                parents=[],
+                parent=None,
                 children=[],
             )
         ],
@@ -920,7 +920,7 @@ def test_exit_mandatory_group_one_feature_with_instance_cardinality(listener):
         instance_cardinality=Cardinality([Interval(2, 2)]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.group_specs = [[feature]]
@@ -939,7 +939,7 @@ def test_exit_or_group(listener):
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.group_specs = [[feature]]
@@ -958,7 +958,7 @@ def test_exit_alternative_group(listener):
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.group_specs = [[feature]]
@@ -977,7 +977,7 @@ def test_exit_optional_group_without_instance_cardinality(listener):
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.group_specs = [[feature]]
@@ -996,7 +996,7 @@ def test_exit_optional_group_with_instance_cardinality_lower_changed_to_zero(lis
         instance_cardinality=Cardinality([Interval(3, 5)]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.group_specs = [[feature]]
@@ -1013,7 +1013,7 @@ def test_exit_optional_group_with_instance_cardinality_lower_changed_to_zero(lis
                 instance_cardinality=Cardinality([Interval(0, 5)]),
                 group_type_cardinality=Cardinality([]),
                 group_instance_cardinality=Cardinality([]),
-                parents=[],
+                parent=None,
                 children=[],
             )
         ],
@@ -1027,7 +1027,7 @@ def test_exit_optional_group_with_instance_cardinality_lower_not_changed(listene
         instance_cardinality=Cardinality([Interval(0, 5)]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.group_specs = [[feature]]
@@ -1047,7 +1047,7 @@ def test_exit_cardinality_group_one_value(listener):
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.group_specs = [[feature]]
@@ -1067,7 +1067,7 @@ def test_exit_cardinality_group_multiple_values(listener):
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.group_specs = [[feature]]
@@ -1087,7 +1087,7 @@ def test_exit_cardinality_group_multiple_values_including_asterisk(listener):
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.group_specs = [[feature]]
@@ -1223,7 +1223,7 @@ def test_exit_constraint_line_equivalence(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         "test2": Feature(
@@ -1231,7 +1231,7 @@ def test_exit_constraint_line_equivalence(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     }
@@ -1251,7 +1251,7 @@ def test_exit_constraint_line_implication(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
         "test2": Feature(
@@ -1259,7 +1259,7 @@ def test_exit_constraint_line_implication(listener):
             instance_cardinality=Cardinality([]),
             group_type_cardinality=Cardinality([]),
             group_instance_cardinality=Cardinality([]),
-            parents=[],
+            parent=None,
             children=[],
         ),
     }
@@ -1277,7 +1277,7 @@ def test_exit_features(listener):
         instance_cardinality=Cardinality([]),
         group_type_cardinality=Cardinality([]),
         group_instance_cardinality=Cardinality([]),
-        parents=[],
+        parent=None,
         children=[],
     )
     listener.features = [feature1]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -36,45 +36,29 @@ def test_cardinality_string(intervals: list[Interval], expectation: str):
 
 def test_feature_string():
     feature = Feature(
-        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
     assert str(feature) == "Cheese"
 
 
-def test_add_parent():
-    feature = Feature(
-        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), [], []
-    )
-    parent = Feature("Bread", Cardinality([]), Cardinality([]), Cardinality([]), [], [])
-    feature.add_parent(parent)
-    assert parent in feature.parents
-
-
-def test_add_parent_ignores_already_added_parents():
-    feature = Feature(
-        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), [], []
-    )
-    parent = Feature("Bread", Cardinality([]), Cardinality([]), Cardinality([]), [], [])
-    feature.add_parent(parent)
-    feature.add_parent(parent)
-    assert len(feature.parents) == 1
-    assert parent in feature.parents
-
-
 def test_add_child():
     feature = Feature(
-        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
-    child = Feature("Cheese", Cardinality([]), Cardinality([]), Cardinality([]), [], [])
+    child = Feature(
+        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), None, []
+    )
     feature.add_child(child)
     assert child in feature.children
 
 
 def test_add_child_ignores_already_added_children():
     feature = Feature(
-        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
-    child = Feature("Cheese", Cardinality([]), Cardinality([]), Cardinality([]), [], [])
+    child = Feature(
+        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), None, []
+    )
     feature.add_child(child)
     feature.add_child(child)
     assert len(feature.children) == 1
@@ -83,7 +67,7 @@ def test_add_child_ignores_already_added_children():
 
 def test_constraint_string():
     cardinality = Cardinality([])
-    feature = Feature("Cheese", cardinality, cardinality, cardinality, [], [])
+    feature = Feature("Cheese", cardinality, cardinality, cardinality, None, [])
     constraint = Constraint(True, feature, cardinality, feature, cardinality)
     assert str(constraint) == "Cheese => Cheese"
 
@@ -100,43 +84,43 @@ def test_cardinality_is_valid():
 
 def test_feature_is_required():
     cardinality = Cardinality([Interval(1, 10)])
-    feature = Feature("Cheese", cardinality, cardinality, cardinality, [], [])
+    feature = Feature("Cheese", cardinality, cardinality, cardinality, None, [])
     assert feature.is_required()
 
     cardinality = Cardinality([Interval(0, 10)])
-    feature = Feature("Cheese", cardinality, cardinality, cardinality, [], [])
+    feature = Feature("Cheese", cardinality, cardinality, cardinality, None, [])
     assert not feature.is_required()
 
     cardinality = Cardinality([Interval(0, 0)])
-    feature = Feature("Cheese", cardinality, cardinality, cardinality, [], [])
+    feature = Feature("Cheese", cardinality, cardinality, cardinality, None, [])
     assert not feature.is_required()
 
     cardinality = Cardinality([Interval(1, 1)])
-    feature = Feature("Cheese", cardinality, cardinality, cardinality, [], [])
+    feature = Feature("Cheese", cardinality, cardinality, cardinality, None, [])
     assert feature.is_required()
 
     cardinality = Cardinality([Interval(0, 1)])
-    feature = Feature("Cheese", cardinality, cardinality, cardinality, [], [])
+    feature = Feature("Cheese", cardinality, cardinality, cardinality, None, [])
     assert not feature.is_required()
 
     cardinality = Cardinality([Interval(1, 10), Interval(20, 30), Interval(40, 50)])
-    feature = Feature("Cheese", cardinality, cardinality, cardinality, [], [])
+    feature = Feature("Cheese", cardinality, cardinality, cardinality, None, [])
     assert feature.is_required()
 
     cardinality = Cardinality([Interval(0, 10), Interval(20, 30), Interval(40, 50)])
-    feature = Feature("Cheese", cardinality, cardinality, cardinality, [], [])
+    feature = Feature("Cheese", cardinality, cardinality, cardinality, None, [])
     assert not feature.is_required()
 
     cardinality = Cardinality([Interval(0, 0), Interval(20, 30), Interval(40, 50)])
-    feature = Feature("Cheese", cardinality, cardinality, cardinality, [], [])
+    feature = Feature("Cheese", cardinality, cardinality, cardinality, None, [])
     assert not feature.is_required()
 
     cardinality = Cardinality([Interval(1, 1), Interval(20, 30), Interval(40, 50)])
-    feature = Feature("Cheese", cardinality, cardinality, cardinality, [], [])
+    feature = Feature("Cheese", cardinality, cardinality, cardinality, None, [])
     assert feature.is_required()
 
     cardinality = Cardinality([Interval(0, 1), Interval(20, 30), Interval(40, 50)])
-    feature = Feature("Cheese", cardinality, cardinality, cardinality, [], [])
+    feature = Feature("Cheese", cardinality, cardinality, cardinality, None, [])
     assert not feature.is_required()
 
 
@@ -149,7 +133,7 @@ def test_feature_is_required():
                 Cardinality([Interval(0, None)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             True,
@@ -160,14 +144,14 @@ def test_feature_is_required():
                 Cardinality([Interval(0, 3)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [
                     Feature(
                         "Gouda",
                         Cardinality([Interval(0, None)]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                 ],
@@ -180,14 +164,14 @@ def test_feature_is_required():
                 Cardinality([Interval(0, 3)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [
                     Feature(
                         "Gouda",
                         Cardinality([Interval(0, 4)]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Feature(
@@ -195,7 +179,7 @@ def test_feature_is_required():
                         Cardinality([Interval(0, 3)]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                 ],
@@ -211,7 +195,7 @@ def test_feature_is_unbound(feature: Feature, expectation: bool):
 def test_add_feature():
     cfm = CFM([], [], [])
     feature = Feature(
-        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
     cfm.add_feature(feature)
     assert feature in cfm.features
@@ -220,7 +204,7 @@ def test_add_feature():
 def test_add_feature_ignores_already_added_features():
     cfm = CFM([], [], [])
     feature = Feature(
-        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
     cfm.add_feature(feature)
     cfm.add_feature(feature)
@@ -231,7 +215,7 @@ def test_add_feature_ignores_already_added_features():
 def test_find_feature():
     cfm = CFM([], [], [])
     feature = Feature(
-        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
     cfm.add_feature(feature)
     assert cfm.find_feature("Cheese") == feature
@@ -248,7 +232,7 @@ def test_find_feature():
                         Cardinality([Interval(0, None)]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     )
                 ],
@@ -265,7 +249,7 @@ def test_find_feature():
                         Cardinality([Interval(0, 4)]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     )
                 ],
@@ -288,7 +272,7 @@ def test_find_feature_raises_missing_features_on_empty_feature_list():
 
 def test_find_feature_raises_missing_features():
     bread_feature = Feature(
-        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), None, []
     )
     cfm = CFM([bread_feature], [], [])
 
@@ -302,13 +286,17 @@ def test_partition_children():
         Cardinality([]),
         Cardinality([]),
         Cardinality([]),
-        [],
+        None,
         [
-            Feature("Bread", Cardinality([]), Cardinality([]), Cardinality([]), [], []),
             Feature(
-                "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), [], []
+                "Bread", Cardinality([]), Cardinality([]), Cardinality([]), None, []
             ),
-            Feature("Meat", Cardinality([]), Cardinality([]), Cardinality([]), [], []),
+            Feature(
+                "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), None, []
+            ),
+            Feature(
+                "Meat", Cardinality([]), Cardinality([]), Cardinality([]), None, []
+            ),
         ],
     )
     feature_node = FeatureNode(
@@ -340,7 +328,7 @@ def test_partition_children():
                 Cardinality([]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             FeatureNode("Sandwich#0", []),
@@ -352,7 +340,7 @@ def test_partition_children():
                 Cardinality([]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             FeatureNode("Sandwich#0", [FeatureNode("Bread#0", [])]),
@@ -415,14 +403,14 @@ def test_validate_children(feature_instance: FeatureNode, expectation: bool):
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(2, 3)]),
         Cardinality([Interval(3, 4)]),
-        [],
+        None,
         [
             Feature(
                 "Bread",
                 Cardinality([Interval(2, 2)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             Feature(
@@ -430,7 +418,7 @@ def test_validate_children(feature_instance: FeatureNode, expectation: bool):
                 Cardinality([Interval(0, 1)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             Feature(
@@ -438,7 +426,7 @@ def test_validate_children(feature_instance: FeatureNode, expectation: bool):
                 Cardinality([Interval(0, 1)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
         ],
@@ -486,21 +474,21 @@ def test_validate_feature_instance(feature_instance: FeatureNode, expectation: b
         Cardinality([Interval(1, 1)]),
         Cardinality([Interval(2, 3)]),
         Cardinality([Interval(3, 4)]),
-        [],
+        None,
         [
             Feature(
                 "Bread",
                 Cardinality([Interval(2, 2)]),
                 Cardinality([Interval(1, 1)]),
                 Cardinality([Interval(1, 1)]),
-                [],
+                None,
                 [
                     Feature(
                         "Wheat",
                         Cardinality([Interval(0, 1)]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Feature(
@@ -508,7 +496,7 @@ def test_validate_feature_instance(feature_instance: FeatureNode, expectation: b
                         Cardinality([Interval(0, 1)]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                 ],
@@ -518,7 +506,7 @@ def test_validate_feature_instance(feature_instance: FeatureNode, expectation: b
                 Cardinality([Interval(0, 1)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
             Feature(
@@ -526,7 +514,7 @@ def test_validate_feature_instance(feature_instance: FeatureNode, expectation: b
                 Cardinality([Interval(0, 1)]),
                 Cardinality([]),
                 Cardinality([]),
-                [],
+                None,
                 [],
             ),
         ],
@@ -614,7 +602,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(1, 1)]),
@@ -623,7 +611,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(1, 1)]),
@@ -641,7 +629,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(2, 2)]),
@@ -650,7 +638,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(2, 2)]),
@@ -668,7 +656,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(2, 2)]),
@@ -677,7 +665,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(1, None)]),
@@ -696,7 +684,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(4, None)]),
@@ -705,7 +693,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(1, None)]),
@@ -723,7 +711,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(2, None)]),
@@ -732,7 +720,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(1, None)]),
@@ -749,7 +737,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(2, 2)]),
@@ -758,7 +746,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(1, None)]),
@@ -772,7 +760,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(4, None)]),
@@ -781,7 +769,7 @@ def test_initialize_global_feature_count(
                         Cardinality([]),
                         Cardinality([]),
                         Cardinality([]),
-                        [],
+                        None,
                         [],
                     ),
                     Cardinality([Interval(1, None)]),


### PR DESCRIPTION
We implicitly did this before, but the data structure enabled us to store all transitive parents explicitly.
