### PR TITLE
Remove the deprecated add_child method

### DIFF
--- a/cfmtoolbox/models.py
+++ b/cfmtoolbox/models.py
@@ -44,10 +44,6 @@ class Feature:
     def is_required(self) -> bool:
         return self.instance_cardinality.intervals[0].lower != 0
 
-    def add_child(self, child: "Feature"):
-        if child not in self.children:
-            self.children.append(child)
-
     def is_unbound(self) -> bool:
         return self.instance_cardinality.intervals[-1].upper is None or any(
             child.is_unbound() for child in self.children

--- a/cfmtoolbox/plugins/featureide_import.py
+++ b/cfmtoolbox/plugins/featureide_import.py
@@ -85,7 +85,7 @@ def traverse_xml(element: Element | None, cfm: CFM) -> list[Feature]:
         for child in element:
             feature = parse_feature(child)
             feature.parent = parent
-            parent.add_child(feature)
+            parent.children.append(feature)
             cfm.add_feature(feature)
             traverse_xml(child, cfm)
 

--- a/tests/plugins/test_uvl_export.py
+++ b/tests/plugins/test_uvl_export.py
@@ -75,8 +75,8 @@ def test_serialize_group_cardinality_can_export_to_or():
         [],
     )
 
-    sandwich.add_child(cheese)
-    sandwich.add_child(veggies)
+    sandwich.children.append(cheese)
+    sandwich.children.append(veggies)
 
     assert serialize_group_cardinality(sandwich) == "or"
 
@@ -173,7 +173,7 @@ def test_serialize_root_feature():
         [],
     )
 
-    root.add_child(cheese)
+    root.children.append(cheese)
     root_export = serialize_root_feature(root)
     assert expectation in root_export
 
@@ -236,7 +236,7 @@ def test_serialize_features_can_export_single_child_feature():
         [],
     )
 
-    sandwich.add_child(cheese)
+    sandwich.children.append(cheese)
 
     expectation = """Sandwich cardinality [1..1]
 \t[0..2]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,30 +41,6 @@ def test_feature_string():
     assert str(feature) == "Cheese"
 
 
-def test_add_child():
-    feature = Feature(
-        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), None, []
-    )
-    child = Feature(
-        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), None, []
-    )
-    feature.add_child(child)
-    assert child in feature.children
-
-
-def test_add_child_ignores_already_added_children():
-    feature = Feature(
-        "Bread", Cardinality([]), Cardinality([]), Cardinality([]), None, []
-    )
-    child = Feature(
-        "Cheese", Cardinality([]), Cardinality([]), Cardinality([]), None, []
-    )
-    feature.add_child(child)
-    feature.add_child(child)
-    assert len(feature.children) == 1
-    assert child in feature.children
-
-
 def test_constraint_string():
     cardinality = Cardinality([])
     feature = Feature("Cheese", cardinality, cardinality, cardinality, None, [])


### PR DESCRIPTION
This was removed because it was essentially implementing set-like features on top of a list (i.e., using a set would have been easier). That being said, neither this approach nor using a set would currently work because of the recursive nature of the Feature model. To make things work, we would have to add a custom `__eq__` method to the Feature model. But it looks like we don't need this behavior at all, so let's remove it. 