### PR TITLE
Fix main entrypoint test was consuming pytest args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ extend-select = ["I"]
 [tool.pytest.ini_options]
 addopts = "--cov=cfmtoolbox --cov-report term-missing --cov-report html"
 
+[tool.coverage]
+omit = ["cfmtoolbox/__main__.py"]
+
 [tool.mypy]
 check_untyped_defs = true
 

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -7,17 +7,6 @@ from cfmtoolbox import CFM
 from cfmtoolbox.toolbox import CFMToolbox
 
 
-def test_entrypoint_runs_cli(capsys):
-    with pytest.raises(SystemExit):
-        from cfmtoolbox.__main__ import app
-
-        assert app
-
-    stdout, stderr = capsys.readouterr()
-    assert stdout == ""
-    assert "Missing command." in stderr
-
-
 def test_import_model_without_import_path():
     app = CFMToolbox()
     assert app.import_path is None


### PR DESCRIPTION
Our main entrypoint is running the CLI which will automatically consume command line arguments such as `-vv` for pytest. That's undesirable because it's messing with our CLI's output which influences tests. Given that we already test CLI commands directly, I propose omitting the minimal `__main__.py` file from coverage.