### PR TITLE
Simplify the FeatureIDE import example

### DIFF
--- a/docs/plugins/featureide-import.md
+++ b/docs/plugins/featureide-import.md
@@ -6,21 +6,19 @@ Files with the `.xml` extension are automatically considered a FeatureIDE featur
 
 ## Usage example
 
-Create a basic FeatureIDE feature model in a file named `basic-sandwich.xml`:
+Create a basic FeatureIDE feature model file named `sandwich.xml` with the following content:
 
-```bash
-cat <<EOT >> basic-sandwich.xml
+```xml
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <featureModel>
     <struct>
         <feature abstract="true" mandatory="true" name="Sandwich"/>
     </struct>
 </featureModel>
-EOT
 ```
 
 Import the feature model into the CFM Toolbox and show some basic information about it:
 
 ```bash
-python3 -m cfmtoolbox --import basic-sandwich.xml debug
+python3 -m cfmtoolbox --import sandwich.xml debug
 ```


### PR DESCRIPTION
Before this change, the docs were harder to follow because more shell syntax knowledge was required.